### PR TITLE
일반 로그인 DTO 추가

### DIFF
--- a/motionit/src/main/java/com/back/motionit/domain/auth/dto/AuthResponse.java
+++ b/motionit/src/main/java/com/back/motionit/domain/auth/dto/AuthResponse.java
@@ -1,0 +1,17 @@
+package com.back.motionit.domain.auth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class AuthResponse {
+	private String accessToken;
+	private Long userId;
+	private String email;
+	private String nickname;
+}

--- a/motionit/src/main/java/com/back/motionit/domain/auth/dto/LoginRequest.java
+++ b/motionit/src/main/java/com/back/motionit/domain/auth/dto/LoginRequest.java
@@ -1,0 +1,20 @@
+package com.back.motionit.domain.auth.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class LoginRequest {
+
+	@NotBlank(message = "이메일은 필수입니다.")
+	@Email(message = "이메일 형식이 올바르지 않습니다.")
+	private String email;
+
+	@NotBlank(message = "비밀번호는 필수입니다.")
+	private String password;
+}

--- a/motionit/src/main/java/com/back/motionit/domain/auth/dto/SignupRequest.java
+++ b/motionit/src/main/java/com/back/motionit/domain/auth/dto/SignupRequest.java
@@ -1,0 +1,27 @@
+package com.back.motionit.domain.auth.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class SignupRequest {
+
+	@NotBlank(message = "이메일은 필수입니다.")
+	@Email(message = "이메일 형식이 올바르지 않습니다.")
+	@Size(max = 100, message = "이메일은 100자 이내.")
+	private String email;
+
+	@NotBlank(message = "비밀번호는 필수입니다.")
+	@Size(min = 8, max = 30, message = "비밀번호는 8~30자여야 합니다.")
+	private String password;
+
+	@NotBlank(message = "닉네임은 필수입니다.")
+	@Size(min = 3, max = 10, message = "닉네임은 3~10자여야 합니다.")
+	private String nickname;
+}


### PR DESCRIPTION
<!--
  템플릿은 아직 PR 작성이 익숙하지 않으신 분들을 위해서 제공하는 가이드입니다!
  리뷰어 또는 이 PR을 보게 될 다른 사람들이 이 PR을 보는데 참고할 수 있는 내용이 있다면 포함해서 작성해주시면 됩니다.
-->

## 관련 이슈

- Close #24 

## PR / 과제 설명 
- 일반 로그인용 DTO 추가
    - `AuthResponse`:` accessToken`,` userId`, `email`, `nickname `(RT는 본문 제외)
    - `LoginRequest`: `email`, `password` (형식/필수 검증)
    - `SignupRequest`: `email`(`@Email`, ≤100자), `password`(8~30자), `nickname`(3~10자)
- 정규화/중복검사: DTO가 아닌 서비스에서 처리
