### PR TITLE
닉네임 중복 불가 수정 

### DIFF
--- a/motionit/src/main/java/com/back/motionit/domain/auth/local/api/LocalAuthApi.java
+++ b/motionit/src/main/java/com/back/motionit/domain/auth/local/api/LocalAuthApi.java
@@ -26,8 +26,8 @@ public interface LocalAuthApi {
 	@ApiResponses({
 		@ApiResponse(responseCode = "201", description = "회원가입 성공",
 			content = @Content(schema = @Schema(implementation = AuthResponse.class))),
-		@ApiResponse(responseCode = "400", description = "유효하지 않은 입력값"),
-		@ApiResponse(responseCode = "409", description = "이메일 중복 (U-100)")
+		@ApiResponse(responseCode = "400", description = "유효하지 않은 입력값 (C-002)"),
+		@ApiResponse(responseCode = "409", description = "이메일 중복 (U-100) 또는 닉네임 중복 (U-101)")
 	})
 	@PostMapping("/signup")
 	@ResponseStatus(HttpStatus.CREATED)
@@ -37,7 +37,7 @@ public interface LocalAuthApi {
 	@ApiResponses({
 		@ApiResponse(responseCode = "200", description = "로그인 성공",
 			content = @Content(schema = @Schema(implementation = AuthResponse.class))),
-		@ApiResponse(responseCode = "401", description = "이메일 또는 비밀번호 불일치 (U-101)")
+		@ApiResponse(responseCode = "401", description = "이메일 또는 비밀번호 불일치 (U-102)")
 	})
 	@PostMapping("/login")
 	ResponseData<AuthResponse> login(@Valid @RequestBody LoginRequest request);
@@ -45,7 +45,7 @@ public interface LocalAuthApi {
 	@Operation(summary = "로그아웃", description = "리프레시 토큰을 제거하여 로그아웃합니다.")
 	@ApiResponses({
 		@ApiResponse(responseCode = "200", description = "로그아웃 성공"),
-		@ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음 (U-102)")
+		@ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음 (U-103)")
 	})
 	@PostMapping("/logout")
 	ResponseData<Void> logout(@RequestParam Long userId);

--- a/motionit/src/main/java/com/back/motionit/domain/auth/local/controller/LocalAuthController.java
+++ b/motionit/src/main/java/com/back/motionit/domain/auth/local/controller/LocalAuthController.java
@@ -24,19 +24,19 @@ public class LocalAuthController implements LocalAuthApi {
 	@Override
 	public ResponseData<AuthResponse> signup(SignupRequest request) {
 		AuthResponse response = localAuthService.signup(request);
-		return ResponseData.success("201", "회원가입이 완료되었습니다.", response);
+		return ResponseData.success(response);
 	}
 
 	@Override
 	public ResponseData<AuthResponse> login(LoginRequest request) {
 		AuthResponse response = localAuthService.login(request);
-		return ResponseData.success("로그인이 완료되었습니다.", response);
+		return ResponseData.success(response);
 	}
 
 	@Override
 	public ResponseData<Void> logout(Long userId) {
 		// TODO: JWT 인증 완성 후 @AuthenticationPrincipal로 userId 받기
 		localAuthService.logout(userId);
-		return ResponseData.success("로그아웃이 완료되었습니다.", null);
+		return ResponseData.success(null);
 	}
 }

--- a/motionit/src/main/java/com/back/motionit/domain/auth/local/service/LocalAuthService.java
+++ b/motionit/src/main/java/com/back/motionit/domain/auth/local/service/LocalAuthService.java
@@ -31,6 +31,10 @@ public class LocalAuthService {
 			throw new BusinessException(AuthErrorCode.EMAIL_DUPLICATED);
 		}
 
+		if (userRepository.existsByNickname(request.getNickname())) {
+			throw new BusinessException(AuthErrorCode.NICKNAME_DUPLICATED);
+		}
+
 		String encodedPassword = passwordEncoder.encode(request.getPassword());
 
 		User user = User.builder()

--- a/motionit/src/main/java/com/back/motionit/domain/user/repository/UserRepository.java
+++ b/motionit/src/main/java/com/back/motionit/domain/user/repository/UserRepository.java
@@ -13,4 +13,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
 	Optional<User> findByKakaoId(Long kakaoId);
 
 	boolean existsByEmail(String email);
+
+	boolean existsByNickname(String nickname);
 }

--- a/motionit/src/main/java/com/back/motionit/global/error/code/AuthErrorCode.java
+++ b/motionit/src/main/java/com/back/motionit/global/error/code/AuthErrorCode.java
@@ -10,8 +10,9 @@ import lombok.RequiredArgsConstructor;
 public enum AuthErrorCode implements ErrorCode {
 
 	EMAIL_DUPLICATED(HttpStatus.CONFLICT, "U-100", "이미 사용중인 이메일입니다."),
-	LOGIN_FAILED(HttpStatus.UNAUTHORIZED, "U-101", "이메일 또는 비밀번호가 일치하지 않습니다."),
-	USER_NOT_FOUND(HttpStatus.NOT_FOUND, "U-102", "사용자를 찾을 수 없습니다.");
+	NICKNAME_DUPLICATED(HttpStatus.CONFLICT, "U-101", "이미 사용중인 닉네임입니다."),
+	LOGIN_FAILED(HttpStatus.UNAUTHORIZED, "U-102", "이메일 또는 비밀번호가 일치하지 않습니다."),
+	USER_NOT_FOUND(HttpStatus.NOT_FOUND, "U-103", "사용자를 찾을 수 없습니다.");
 
 	private final HttpStatus status;
 	private final String code;


### PR DESCRIPTION
<!--
  템플릿은 아직 PR 작성이 익숙하지 않으신 분들을 위해서 제공하는 가이드입니다!
  리뷰어 또는 이 PR을 보게 될 다른 사람들이 이 PR을 보는데 참고할 수 있는 내용이 있다면 포함해서 작성해주시면 됩니다.
-->

## 관련 이슈

- Close #44 

## PR / 과제 설명 

- 카카오 정책상 닉네임 중복이 허용되지 않으므로, 일반 로그인에서도 닉네임 중복을 방지해야 함

- API 명세 수정
  - `localAuthController.java`
  - `LocalAuthApi.java`
