### PR TITLE
방참여 서비스 로직 리팩터링 운동방 생성시 방장권한으로 자동참여

### DIFF
--- a/motionit/src/main/java/com/back/motionit/domain/challenge/participant/entity/ChallengeParticipantRole.java
+++ b/motionit/src/main/java/com/back/motionit/domain/challenge/participant/entity/ChallengeParticipantRole.java
@@ -6,7 +6,7 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum ChallengeParticipantRole {
-	ADMIN("admin"),
+	HOST("host"),
 	NORMAL("normal");
 
 	private final String value;


### PR DESCRIPTION
<!--
  템플릿은 아직 PR 작성이 익숙하지 않으신 분들을 위해서 제공하는 가이드입니다!
  리뷰어 또는 이 PR을 보게 될 다른 사람들이 이 PR을 보는데 참고할 수 있는 내용이 있다면 포함해서 작성해주시면 됩니다.
-->

## 관련 이슈

- Close #49 

## PR / 과제 설명 
- ChallengeRoom 생성 시, 방장이 자동으로 방장(Host) 권한으로 방에 참여되도록 변경
- 관련 테스트 코드 추가
- 방참여 관련 권한 Enum 값 변경
   - 방장: ADMIN -> HOST
   - 일반 참여자: NORMAL -> (변경 없음)
