### PR TITLE
AWS S3 연동

### DIFF
--- a/motionit/.gitignore
+++ b/motionit/.gitignore
@@ -5,6 +5,9 @@ build/
 !**/src/main/**/build/
 !**/src/test/**/build/
 
+*.yml
+!application-example.yml
+
 ### STS ###
 .apt_generated
 .classpath

--- a/motionit/build.gradle.kts
+++ b/motionit/build.gradle.kts
@@ -50,6 +50,14 @@ dependencies {
     runtimeOnly("io.jsonwebtoken:jjwt-impl:0.12.6")
     runtimeOnly("io.jsonwebtoken:jjwt-jackson:0.12.6")
     implementation("com.google.apis:google-api-services-youtube:v3-rev222-1.25.0")
+
+    // AWS
+    implementation("software.amazon.awssdk:s3:2.27.21")
+    implementation("software.amazon.awssdk:auth:2.27.21")
+    implementation("software.amazon.awssdk:regions:2.27.21")
+    implementation("software.amazon.awssdk:s3:2.27.21")
+    implementation("software.amazon.awssdk:cloudfront:2.27.21")
+    implementation("com.amazonaws:aws-java-sdk-cloudfront:1.12.782")
 }
 
 
@@ -68,9 +76,9 @@ checkstyle {
     toolVersion = "8.24"
     configFile = rootProject.file("config/checkstyle/naver-checkstyle-rules.xml")
     configProperties = mapOf(
-        "suppressionFile" to rootProject
-            .file("config/checkstyle/naver-checkstyle-suppressions.xml")
-            .absolutePath
+            "suppressionFile" to rootProject
+                    .file("config/checkstyle/naver-checkstyle-suppressions.xml")
+                    .absolutePath
     )
 }
 

--- a/motionit/src/main/java/com/back/motionit/domain/storage/api/StorageApi.java
+++ b/motionit/src/main/java/com/back/motionit/domain/storage/api/StorageApi.java
@@ -1,0 +1,39 @@
+package com.back.motionit.domain.storage.api;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import com.back.motionit.domain.storage.api.response.StorageHttp;
+import com.back.motionit.domain.storage.dto.CdnUrlResponse;
+import com.back.motionit.domain.storage.dto.CreateUploadUrlRequest;
+import com.back.motionit.domain.storage.dto.UploadUrlResponse;
+import com.back.motionit.global.respoonsedata.ResponseData;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+
+@Tag(name = "AWS S3 저장소", description = "운동방, 사용자 프로필 이미지를 S3에 업로드하기 위한 API")
+public interface StorageApi {
+	@PostMapping("/upload-url")
+	@Operation(summary = "AWS S3 업로드 url 생성", description = "이미지를 업로드 할 수 있는 Pre-signed URL을 생성합니다.")
+	@ApiResponses({
+		@ApiResponse(responseCode = StorageHttp.CREATE_AWS_URL_SUCCESS_CODE, description = StorageHttp.CREATE_AWS_URL_SUCCESS_MESSAGE,
+			content = @Content(schema = @Schema(implementation = UploadUrlResponse.class)))
+	})
+	ResponseData<UploadUrlResponse> createUploadUrl(@RequestBody @Valid CreateUploadUrlRequest request);
+
+	@GetMapping("/cdn-url")
+	@Operation(summary = "AWS cdn url 생성", description = "이미지를 확인 할 수 있는 URL을 생성합니다.")
+	@ApiResponses({
+		@ApiResponse(responseCode = StorageHttp.CREATE_CDN_URL_SUCCESS_CODE, description = StorageHttp.CREATE_CDN_URL_SUCCESS_MESSAGE,
+			content = @Content(schema = @Schema(implementation = CdnUrlResponse.class)))
+	})
+	ResponseData<CdnUrlResponse> signCdnUrl(@RequestParam("key") String key);
+}

--- a/motionit/src/main/java/com/back/motionit/domain/storage/api/response/StorageHttp.java
+++ b/motionit/src/main/java/com/back/motionit/domain/storage/api/response/StorageHttp.java
@@ -1,0 +1,9 @@
+package com.back.motionit.domain.storage.api.response;
+
+public class StorageHttp {
+	public static final String CREATE_AWS_URL_SUCCESS_CODE = "201";
+	public static final String CREATE_AWS_URL_SUCCESS_MESSAGE = "Success to create pre signed url";
+
+	public static final String CREATE_CDN_URL_SUCCESS_CODE = "201";
+	public static final String CREATE_CDN_URL_SUCCESS_MESSAGE = "Success to create CDN url";
+}

--- a/motionit/src/main/java/com/back/motionit/domain/storage/controller/StorageController.java
+++ b/motionit/src/main/java/com/back/motionit/domain/storage/controller/StorageController.java
@@ -1,0 +1,55 @@
+package com.back.motionit.domain.storage.controller;
+
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.back.motionit.domain.storage.api.StorageApi;
+import com.back.motionit.domain.storage.api.response.StorageHttp;
+import com.back.motionit.domain.storage.dto.CdnUrlResponse;
+import com.back.motionit.domain.storage.dto.CreateUploadUrlRequest;
+import com.back.motionit.domain.storage.dto.UploadUrlResponse;
+import com.back.motionit.global.respoonsedata.ResponseData;
+import com.back.motionit.global.service.AwsCdnSignService;
+import com.back.motionit.global.service.AwsS3Service;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/storage")
+public class StorageController implements StorageApi {
+
+	private final AwsS3Service s3Service;
+	private final AwsCdnSignService cdnSignService;
+
+	@Override
+	public ResponseData<UploadUrlResponse> createUploadUrl(@RequestBody @Valid CreateUploadUrlRequest request) {
+		String objectKey = (request.objectKey() == null || request.objectKey().isBlank())
+			? s3Service.buildObjectKey(request.originalFileName())
+			: request.objectKey();
+
+		String url = s3Service.createUploadUrl(
+			objectKey,
+			request.contentType()
+		);
+
+		return ResponseData.success(
+			StorageHttp.CREATE_AWS_URL_SUCCESS_CODE,
+			StorageHttp.CREATE_AWS_URL_SUCCESS_MESSAGE,
+			new UploadUrlResponse(objectKey, url)
+		);
+	}
+
+	@Override
+	public ResponseData<CdnUrlResponse> signCdnUrl(@RequestParam("key") String key) {
+		String url = cdnSignService.sign(key);
+		return ResponseData.success(
+			StorageHttp.CREATE_CDN_URL_SUCCESS_CODE,
+			StorageHttp.CREATE_CDN_URL_SUCCESS_MESSAGE,
+			new CdnUrlResponse(key, url)
+		);
+	}
+}

--- a/motionit/src/main/java/com/back/motionit/domain/storage/dto/CdnUrlResponse.java
+++ b/motionit/src/main/java/com/back/motionit/domain/storage/dto/CdnUrlResponse.java
@@ -1,0 +1,7 @@
+package com.back.motionit.domain.storage.dto;
+
+public record CdnUrlResponse(
+	String objectKey,
+	String cdnUrl
+) {
+}

--- a/motionit/src/main/java/com/back/motionit/domain/storage/dto/CreateUploadUrlRequest.java
+++ b/motionit/src/main/java/com/back/motionit/domain/storage/dto/CreateUploadUrlRequest.java
@@ -1,0 +1,10 @@
+package com.back.motionit.domain.storage.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record CreateUploadUrlRequest(
+	@NotBlank String originalFileName,
+	@NotBlank String contentType,
+	String objectKey
+) {
+}

--- a/motionit/src/main/java/com/back/motionit/domain/storage/dto/UploadUrlResponse.java
+++ b/motionit/src/main/java/com/back/motionit/domain/storage/dto/UploadUrlResponse.java
@@ -1,0 +1,7 @@
+package com.back.motionit.domain.storage.dto;
+
+public record UploadUrlResponse(
+	String objectKey,
+	String uploadUrl
+) {
+}

--- a/motionit/src/main/java/com/back/motionit/global/config/aws/AwsS3Config.java
+++ b/motionit/src/main/java/com/back/motionit/global/config/aws/AwsS3Config.java
@@ -1,0 +1,33 @@
+package com.back.motionit.global.config.aws;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+
+@Configuration
+public class AwsS3Config {
+
+	@Value("${aws.region}")
+	private String region;
+
+	@Bean
+	public S3Client s3Client() {
+		return S3Client.builder()
+			.region(Region.of(region))
+			.credentialsProvider(DefaultCredentialsProvider.create())
+			.build();
+	}
+
+	@Bean
+	public S3Presigner s3Presigner() {
+		return S3Presigner.builder()
+			.region(Region.of(region))
+			.credentialsProvider(DefaultCredentialsProvider.create())
+			.build();
+	}
+}

--- a/motionit/src/main/java/com/back/motionit/global/config/aws/CloudFrontSignConfig.java
+++ b/motionit/src/main/java/com/back/motionit/global/config/aws/CloudFrontSignConfig.java
@@ -1,0 +1,86 @@
+package com.back.motionit.global.config.aws;
+
+import java.io.File;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.security.PrivateKey;
+import java.time.Instant;
+import java.util.Date;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.amazonaws.services.cloudfront.CloudFrontUrlSigner;
+import com.amazonaws.services.cloudfront.util.SignerUtils;
+import com.back.motionit.global.error.code.ConfigErrorCode;
+import com.back.motionit.global.error.exception.BusinessException;
+
+@Configuration
+public class CloudFrontSignConfig {
+
+	@Value("${aws.cloudfront.domain}")
+	private String cloudFrontDomain;
+
+	@Value("${aws.cloudfront.key-id}")
+	private String keyPairId;
+
+	@Value("${aws.cloudfront.private-key-path}")
+	private String privateKeyPath;
+
+	@Bean
+	public CloudFrontSigner cloudFrontSigner() {
+		return new CloudFrontSigner(cloudFrontDomain, keyPairId, loadPrivateKey(privateKeyPath));
+	}
+
+	private PrivateKey loadPrivateKey(String location) {
+		try {
+			if (location.startsWith("classpath:")) {
+				String cp = location.replace("classpath:", "");
+				try (InputStream in = getClass().getResourceAsStream(cp)) {
+					if (in == null) {
+						throw new IllegalStateException("Classpath resource not found: " + cp);
+					}
+					Path tmp = Files.createTempFile("cf-key-", ".pem");
+					Files.copy(in, tmp, StandardCopyOption.REPLACE_EXISTING);
+					try {
+						return SignerUtils.loadPrivateKey(tmp.toFile());
+					} finally {
+						Files.deleteIfExists(tmp);
+					}
+				}
+			} else {
+				String path = location.replaceFirst("^file:", "");
+				return SignerUtils.loadPrivateKey(new File(path));
+			}
+		} catch (Exception e) {
+			throw new BusinessException(ConfigErrorCode.FAILED_LOAD_PRIVATE_KEY);
+		}
+	}
+
+	public static class CloudFrontSigner {
+		private final String domain;
+		private final String keyPairId;
+		private final PrivateKey privateKey;
+
+		public CloudFrontSigner(String domain, String keyPairId, PrivateKey privateKey) {
+			this.domain = domain;
+			this.keyPairId = keyPairId;
+			this.privateKey = privateKey;
+		}
+
+		public String signUrl(String objectKey, Instant expiresAt) {
+			String resourceUrl = String.format("https://%s/%s", domain, objectKey);
+			Date expires = Date.from(expiresAt);
+			try {
+				return CloudFrontUrlSigner.getSignedURLWithCannedPolicy(
+					resourceUrl, keyPairId, privateKey, expires
+				);
+			} catch (Exception e) {
+				throw new BusinessException(ConfigErrorCode.FAILED_SIGN_CLOUD_FRONT_URL);
+			}
+		}
+	}
+}

--- a/motionit/src/main/java/com/back/motionit/global/error/code/ConfigErrorCode.java
+++ b/motionit/src/main/java/com/back/motionit/global/error/code/ConfigErrorCode.java
@@ -1,0 +1,17 @@
+package com.back.motionit.global.error.code;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ConfigErrorCode implements ErrorCode {
+	FAILED_SIGN_CLOUD_FRONT_URL(HttpStatus.BAD_REQUEST, "S-001", "AWS CloudFront URL Sign 실패"),
+	FAILED_LOAD_PRIVATE_KEY(HttpStatus.BAD_REQUEST, "S-002", "AWS private key 로드 실패");
+
+	private final HttpStatus status;
+	private final String code;
+	private final String message;
+}

--- a/motionit/src/main/java/com/back/motionit/global/service/AwsCdnSignService.java
+++ b/motionit/src/main/java/com/back/motionit/global/service/AwsCdnSignService.java
@@ -1,0 +1,26 @@
+package com.back.motionit.global.service;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import com.back.motionit.global.config.aws.CloudFrontSignConfig;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class AwsCdnSignService {
+
+	private final CloudFrontSignConfig.CloudFrontSigner signer;
+
+	@Value("${aws.cloudfront.signed-url-minutes:10}")
+	private long signedMinutes;
+
+	public String sign(String objectKey) {
+		Instant expires = Instant.now().plus(signedMinutes, ChronoUnit.MINUTES);
+		return signer.signUrl(objectKey, expires);
+	}
+}

--- a/motionit/src/main/java/com/back/motionit/global/service/AwsS3Service.java
+++ b/motionit/src/main/java/com/back/motionit/global/service/AwsS3Service.java
@@ -1,0 +1,74 @@
+package com.back.motionit.global.service;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.UUID;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedPutObjectRequest;
+
+@Service
+@RequiredArgsConstructor
+public class AwsS3Service {
+
+	private final S3Client s3;
+	private final S3Presigner preSigner;
+
+	@Value("${aws.s3.bucket-name}")
+	private String bucket;
+
+	@Value("${aws.s3.key-prefix}")
+	private String keyPrefix;
+
+	@Value("${aws.s3.presign-minutes:10}")
+	private long preSignMinutes;
+
+	public String buildObjectKey(String originalFileName) {
+		String ext = "";
+		int dot = originalFileName.lastIndexOf('.');
+		if (dot > -1) {
+			ext = originalFileName.substring(dot);
+		}
+
+		String datePath = java.time.LocalDate.now().toString().replace("-", "/");
+		String uuid = UUID.randomUUID().toString();
+		String prefix = (keyPrefix == null || keyPrefix.isBlank()) ? "" : keyPrefix + "/";
+		return String.format("%s%s/%s%s", prefix, datePath, uuid, ext);
+	}
+
+	public String createUploadUrl(String objectKey, String contentType) {
+		PutObjectRequest put = PutObjectRequest.builder()
+			.bucket(bucket)
+			.key(objectKey)
+			.contentType(contentType)
+			.build();
+
+		PresignedPutObjectRequest pre = preSigner.presignPutObject(b -> b
+			.signatureDuration(Duration.ofMinutes(preSignMinutes))
+			.putObjectRequest(put)
+		);
+
+		return pre.url().toString();
+	}
+
+	public void delete(String objectKey) {
+		s3.deleteObject(DeleteObjectRequest.builder()
+			.bucket(bucket)
+			.key(objectKey)
+			.build()
+		);
+	}
+
+	public static String encodeFileName(String name) {
+		return URLEncoder.encode(name, StandardCharsets.UTF_8)
+			.replace("+", "%20");
+	}
+}

--- a/motionit/src/main/java/com/back/motionit/security/SecurityConfig.java
+++ b/motionit/src/main/java/com/back/motionit/security/SecurityConfig.java
@@ -1,0 +1,60 @@
+package com.back.motionit.security;
+
+import java.util.List;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.header.writers.frameoptions.XFrameOptionsHeaderWriter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+	@Bean
+	SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+		http
+			.cors(cors -> cors.configurationSource(corsConfigurationSource()))
+			.csrf((csrf) -> csrf.disable())
+			.authorizeHttpRequests((authorizeHttpRequests) -> authorizeHttpRequests
+				.requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
+				.requestMatchers("/favicon.ico").permitAll()
+				.requestMatchers("/h2-console/**").permitAll()
+				.requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()
+				.requestMatchers("/api/v1/storage/**").permitAll()
+				.anyRequest().authenticated())
+			.headers((headers) -> headers
+				.addHeaderWriter(new XFrameOptionsHeaderWriter(
+					XFrameOptionsHeaderWriter.XFrameOptionsMode.SAMEORIGIN)));
+		return http.build();
+	}
+
+	@Bean
+	public PasswordEncoder passwordEncoder() {
+		return new BCryptPasswordEncoder();
+	}
+
+	@Bean
+	public CorsConfigurationSource corsConfigurationSource() {
+		CorsConfiguration configuration = new CorsConfiguration();
+		configuration.setAllowedOrigins(List.of("http://localhost:3000"));
+		configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));
+		configuration.setAllowedHeaders(List.of("*"));
+		configuration.setAllowCredentials(true);
+
+		UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+		source.registerCorsConfiguration("/**", configuration);
+		return source;
+	}
+}

--- a/motionit/src/main/resources/application-dev.yml
+++ b/motionit/src/main/resources/application-dev.yml
@@ -1,6 +1,0 @@
-spring:
-  datasource:
-    url: jdbc:h2:./db_dev;MODE=MySQL
-    username: sa
-    password:
-    driver-class-name: org.h2.Driver

--- a/motionit/src/main/resources/application-example.yml
+++ b/motionit/src/main/resources/application-example.yml
@@ -54,7 +54,22 @@ jwt:
 
 cookie:
   domain: localhost
-  
+
 youtube:
   api:
     key: ${YOUTUBE_API_KEY}
+
+aws:
+  region: ap-northeast-2
+  credentials:
+    access-key: ${ACCESS_KEY}
+    secret-key: ${SECRET_KEY}
+  s3:
+    bucket-name: ${S3_BUCKET_NAME}
+    key-prefix: uploads
+    presign-minutes: 10
+  cloudfront:
+    domain: ${CLOUD_FRONT_DOMAIN}
+    private-key-path: ${KEY_FILE_PATH}
+    key-id: ${CLOUD_FRONT_KEY_ID}
+    signed-url-minutes: 10

--- a/motionit/src/main/resources/application-test.yml
+++ b/motionit/src/main/resources/application-test.yml
@@ -1,3 +1,0 @@
-spring:
-  datasource:
-    url: jdbc:h2:mem:db_dev;MODE=MySQL

--- a/motionit/src/test/java/com/back/motionit/domain/storage/config/TestSecurityConfig.java
+++ b/motionit/src/test/java/com/back/motionit/domain/storage/config/TestSecurityConfig.java
@@ -1,0 +1,20 @@
+package com.back.motionit.domain.storage.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+public class TestSecurityConfig {
+	@Bean
+	SecurityFilterChain testChain(HttpSecurity http) throws Exception {
+		http
+			.csrf(csrf -> csrf.ignoringRequestMatchers("/api/v1/storage/upload-url"))
+			.authorizeHttpRequests(auth -> auth
+				.requestMatchers("/api/v1/storage/**").permitAll()
+				.anyRequest().authenticated()
+			);
+		return http.build();
+	}
+}

--- a/motionit/src/test/java/com/back/motionit/domain/storage/controller/StorageControllerTest.java
+++ b/motionit/src/test/java/com/back/motionit/domain/storage/controller/StorageControllerTest.java
@@ -1,0 +1,138 @@
+package com.back.motionit.domain.storage.controller;
+
+import static org.mockito.BDDMockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.back.motionit.domain.storage.api.response.StorageHttp;
+import com.back.motionit.domain.storage.config.TestSecurityConfig;
+import com.back.motionit.domain.storage.dto.CreateUploadUrlRequest;
+import com.back.motionit.global.service.AwsCdnSignService;
+import com.back.motionit.global.service.AwsS3Service;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@WebMvcTest(controllers = StorageController.class, properties = "jpa.auditing.enabled=false")
+@Import(TestSecurityConfig.class)
+public class StorageControllerTest {
+
+	@Autowired
+	MockMvc mvc;
+
+	@Autowired
+	ObjectMapper mapper;
+
+	@MockitoBean
+	AwsS3Service s3Service;
+
+	@MockitoBean
+	AwsCdnSignService cdnSignService;
+
+	@MockitoBean
+	JpaMetamodelMappingContext jpaMetamodelMappingContext;
+
+	@MockitoBean
+	AuditorAware<?> auditorAware;
+
+	private static final String UPLOAD_URL = "/api/v1/storage/upload-url";
+	private static final String CDN_URL = "/api/v1/storage/cdn-url";
+
+	@Nested
+	@DisplayName("POST " + UPLOAD_URL)
+	class S3Url {
+
+		@Test
+		@DisplayName("성공 - objectKey 미지정 → buildObjectKey 호출 후 presigned URL 반환")
+		void createUploadUrl_generateKey() throws Exception {
+			String generatedKey = "uploads/2025/10/17/uuid.png";
+			String contentType = "image/png";
+			String presigned = "https://s3-presigned-url.example";
+
+			given(s3Service.buildObjectKey("cat.png")).willReturn(generatedKey);
+			given(s3Service.createUploadUrl(generatedKey, contentType)).willReturn(presigned);
+
+			var request = new CreateUploadUrlRequest("cat.png", contentType, null);
+
+			mvc.perform(post(UPLOAD_URL)
+					.contentType(MediaType.APPLICATION_JSON)
+					.content(mapper.writeValueAsString(request)))
+				.andExpect(status().isOk())
+				.andExpect(content().contentType(MediaType.APPLICATION_JSON))
+				.andExpect(jsonPath("$.resultCode").value(StorageHttp.CREATE_AWS_URL_SUCCESS_CODE))
+				.andExpect(jsonPath("$.msg").value(StorageHttp.CREATE_AWS_URL_SUCCESS_MESSAGE))
+				.andExpect(jsonPath("$.data.objectKey").value(generatedKey))
+				.andExpect(jsonPath("$.data.uploadUrl").value(presigned));
+		}
+
+		@Test
+		@DisplayName("성공 - objectKey 지정 → 그대로 사용하여 presigned URL 반환")
+		void createUploadUrl_withGivenKey() throws Exception {
+			String givenKey = "uploads/2025/10/17/my.png";
+			String contentType = "image/png";
+			String presigned = "https://s3-presigned-url-2.example";
+
+			given(s3Service.createUploadUrl(givenKey, contentType)).willReturn(presigned);
+
+			var req = new CreateUploadUrlRequest("cat.png", contentType, givenKey);
+
+			mvc.perform(post(UPLOAD_URL)
+					.contentType(MediaType.APPLICATION_JSON)
+					.content(mapper.writeValueAsString(req)))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.data.objectKey").value(givenKey))
+				.andExpect(jsonPath("$.data.uploadUrl").value(presigned));
+		}
+
+		@Test
+		@DisplayName("실패 - contentType 누락 시 400 (DTO에 @NotBlankk가 붙어있다는 가정)")
+		void badRequest_whenContentTypeMissing() throws Exception {
+			var request = new CreateUploadUrlRequest("cat.png", null, null);
+
+			mvc.perform(post(UPLOAD_URL)
+					.contentType(MediaType.APPLICATION_JSON)
+					.content(mapper.writeValueAsString(request)))
+				.andExpect(status().isBadRequest());
+		}
+	}
+
+	@Nested
+	@DisplayName("GET " + CDN_URL)
+	class CdnUrl {
+
+		@Test
+		@DisplayName("성공 - Key 파라미터로 서명된 CloudFront URL 반환")
+		void signCdnUrl_ok() throws Exception {
+			// given
+			String key = "uploads/2025/10/17/cat.png";
+			String signedUrl = "https://dxxx.cloudfront.net/uploads/2025/10/17/cat.png?Expires=1734460000&Key-Pair-Id=APKAXXX&Signature=abc";
+			given(cdnSignService.sign(key)).willReturn(signedUrl);
+
+			// when/then
+			mvc.perform(get(CDN_URL).param("key", key))
+				.andExpect(status().isOk())
+				.andExpect(content().contentType(MediaType.APPLICATION_JSON))
+				.andExpect(jsonPath("$.resultCode").value(StorageHttp.CREATE_CDN_URL_SUCCESS_CODE))
+				.andExpect(jsonPath("$.msg").value(StorageHttp.CREATE_CDN_URL_SUCCESS_MESSAGE))
+				.andExpect(jsonPath("$.data.objectKey").value(key))
+				.andExpect(jsonPath("$.data.cdnUrl").value(signedUrl));
+		}
+
+		@Test
+		@DisplayName("실패 - key 파라미터 누락 시 400")
+		void signCdnUrl_missingKey_badRequest() throws Exception {
+			mvc.perform(get(CDN_URL)) // key 미전달
+				.andExpect(status().isBadRequest());
+		}
+	}
+}


### PR DESCRIPTION
## 관련 이슈

- Close #36 

## PR / 과제 설명 

build.gradle: AWS 연동에 필요한 의존성 추가

- `StorageController` 추가
   L `createUploadUrl()` 추가: pre-signed URL 생성 메서드
   L `signCdnUrl()` 추가: S3 원본 이미지에 접근 가능한 CloudFront CDN URL 생성 메서드
- `AwsS3Config` 추가: s3 Client와 s3 Presigner 설정
- `CloudFrontSignConfig` 추가: Cloud Front Signer 설정
- AwsCdnSignService 추가: AWS CDN URL 발급 로직 포함
- AwsS3Service 추가: AWS S3 파일 Object Key 생성 로직, 파일 업로드 URL 생성 로직 포함

`.gitignore`: .yml 파일 깃에 포함되지 않도록 추가. 환경변수값 변경사항을 추적하기 위해` application-example.yml `추가

