### PR TITLE
소켓 통신 Configuration 추가

### DIFF
--- a/motionit/build.gradle.kts
+++ b/motionit/build.gradle.kts
@@ -33,6 +33,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-validation")
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("org.springframework.boot:spring-boot-starter-oauth2-client")
+    implementation("org.springframework.boot:spring-boot-starter-websocket")
     compileOnly("org.projectlombok:lombok")
     developmentOnly("org.springframework.boot:spring-boot-devtools")
     runtimeOnly("com.h2database:h2")

--- a/motionit/src/main/java/com/back/motionit/global/config/WebSocketConfig.java
+++ b/motionit/src/main/java/com/back/motionit/global/config/WebSocketConfig.java
@@ -1,0 +1,25 @@
+package com.back.motionit.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@Configuration
+@EnableWebSocketMessageBroker
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+	@Override
+	public void registerStompEndpoints(StompEndpointRegistry registry) {
+		registry.addEndpoint("/ws")
+			.setAllowedOriginPatterns("*")
+			.withSockJS();
+	}
+
+	@Override
+	public void configureMessageBroker(MessageBrokerRegistry registry) {
+		registry.enableSimpleBroker("/topic");
+		registry.setApplicationDestinationPrefixes("/app");
+	}
+}

--- a/motionit/src/main/java/com/back/motionit/global/event/Broadcaster.java
+++ b/motionit/src/main/java/com/back/motionit/global/event/Broadcaster.java
@@ -1,0 +1,5 @@
+package com.back.motionit.global.event;
+
+public interface Broadcaster<T> {
+	void onCreated(T event);
+}

--- a/motionit/src/main/java/com/back/motionit/global/event/EventPublisher.java
+++ b/motionit/src/main/java/com/back/motionit/global/event/EventPublisher.java
@@ -1,0 +1,17 @@
+package com.back.motionit.global.event;
+
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class EventPublisher {
+
+	private final ApplicationEventPublisher publisher;
+
+	public <T> void publishEvent(T event) {
+		publisher.publishEvent(event);
+	}
+}


### PR DESCRIPTION
## 관련 이슈

- Close #45 

## PR / 과제 설명 

- 소켓 통신에 필요한 Configuration 구성
- STOMP 소켓 통신 사용: Java Spring과 Next.js에서 호환 가능한 웹 소켓 라이브러리
- WebSocketConfig 클래스 추가: 웹 소켓 통신을 구성하는 Configuration, `@EnableWebSocketMessageBroker` 어노테이션을 통해서 WebSocket 메시징을 활성화
   L `registerStompEndpoints`: WebSocket 엔드포인트 등록
   L `configureMessageBroker`: 메세지 브로커 설정

- EventPublisher 클래스 추가: 이벤트 등록 클래스
**활용 예시**
```
@Service
@RequiredArgsConstructor
public class ChallengeRoomService {

    private final EventPublisher eventPublisher;

    @Transactional
    public CreateRoomResponse createRoom(CreateRoomRequest request, MultipartFile image) {
        ChallengeRoom saved = challengeRoomRepository.save(mapToRoomObject(request, image));
        eventPublisher.publishForRoom(new ChallengeRoomCreated(saved.getId())); // ✅ 정상 동작
        return CreateRoomResponse.of(saved);
    }
}
```

- Broadcaster 인터페이스 추가: 이벤트 브로드캐스트 인터페이스, 클라이언트 측에서 구독중인 이벤트를 받을 수 있다.
**활용 예시**
```
@Component
@RequiredArgsConstructor
public class RoomBroadcaster implements Broadcaster<ChallengeRoomCreated> {

    private final SimpMessagingTemplate messagingTemplate;

    @Override
    public void onCreated(ChallengeRoomCreated event) {
        messagingTemplate.convertAndSend("/topic/challenge/rooms", event);
    }
}
```
