### PR TITLE
웹 소켓 인증 인가 추가

### DIFF
--- a/motionit/build.gradle.kts
+++ b/motionit/build.gradle.kts
@@ -30,6 +30,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-batch")
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
     implementation("org.springframework.boot:spring-boot-starter-security")
+    implementation("org.springframework.security:spring-security-messaging")
     implementation("org.springframework.boot:spring-boot-starter-validation")
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("org.springframework.boot:spring-boot-starter-oauth2-client")

--- a/motionit/src/main/java/com/back/motionit/security/CustomAuthenticationFilter.java
+++ b/motionit/src/main/java/com/back/motionit/security/CustomAuthenticationFilter.java
@@ -76,8 +76,9 @@ public class CustomAuthenticationFilter extends OncePerRequestFilter {
 		String headerAuthorization = requestContext.getHeader("Authorization", "");
 
 		if (!headerAuthorization.isBlank()) {
-			if (!headerAuthorization.startsWith("Bearer "))
+			if (!headerAuthorization.startsWith("Bearer ")) {
 				throw new BusinessException(AuthErrorCode.AUTH_HEADER_INVALID_SCHEME);
+			}
 
 			String[] headerAuthorizationBits = headerAuthorization.split(" ");
 

--- a/motionit/src/main/java/com/back/motionit/security/config/WebSocketInboundConfig.java
+++ b/motionit/src/main/java/com/back/motionit/security/config/WebSocketInboundConfig.java
@@ -1,0 +1,20 @@
+package com.back.motionit.security.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.ChannelRegistration;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+import com.back.motionit.security.socket.StompAuthChannelInterceptor;
+
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebSocketInboundConfig implements WebSocketMessageBrokerConfigurer {
+	private final StompAuthChannelInterceptor authInterceptor;
+
+	@Override
+	public void configureClientInboundChannel(ChannelRegistration registration) {
+		registration.interceptors(authInterceptor);
+	}
+}

--- a/motionit/src/main/java/com/back/motionit/security/socket/StompAuthChannelInterceptor.java
+++ b/motionit/src/main/java/com/back/motionit/security/socket/StompAuthChannelInterceptor.java
@@ -1,0 +1,66 @@
+package com.back.motionit.security.socket;
+
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.stereotype.Component;
+
+import com.back.motionit.security.jwt.JwtTokenProvider;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class StompAuthChannelInterceptor implements ChannelInterceptor {
+
+	private final JwtTokenProvider tokenProvider;
+
+	@Override
+	public Message<?> preSend(Message<?> message, MessageChannel channel) {
+		var accessor = StompHeaderAccessor.wrap(message);
+		var command = accessor.getCommand();
+
+		if (StompCommand.CONNECT.equals(command)) {
+			String auth = accessor.getFirstNativeHeader("Authorization");
+			Long userId = verifyJwtAndGetUserId(auth);
+
+			if (userId == null) {
+				var authToken = new UsernamePasswordAuthenticationToken(userId, null, List.of());
+				accessor.setUser(authToken);
+			}
+
+			return MessageBuilder.createMessage(message.getPayload(), accessor.getMessageHeaders());
+		}
+
+		return message;
+	}
+
+	private Long verifyJwtAndGetUserId(String authHeader) {
+		if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+			return null;
+		}
+
+		String token = authHeader.substring(7).trim();
+
+		try {
+			Map<String, Object> payload = tokenProvider.payloadOrNull(token);
+
+			if (payload == null) {
+				return null;
+			}
+
+			Number userId = (Number)payload.get("id");
+
+			return (userId != null) ? userId.longValue() : null;
+		} catch (Exception e) {
+			return null;
+		}
+	}
+}


### PR DESCRIPTION
## 관련 이슈

- Close #67 

## PR / 과제 설명 
- WebSocketInboundConfig 클래스 추가: Inbound 흐름을 처리하기 전, 메시지를 가로채 인증/검증/로깅 등의 전처리 수행
```
클라이언트 ↔ STOMP → WebSocket Broker
   ├─ outbound (서버 → 클라이언트로 전송)
   └─ inbound  (클라이언트 → 서버로 전송)
```

- StompAuthChannelInterceptor 클래스 추가: 위에서 정의한 InboundConfig의 세부 구현 클래스
