### PR TITLE
미션 / 영상 연관 관계 및 비즈니스 로직 재설정

### DIFF
--- a/motionit/src/main/java/com/back/motionit/domain/challenge/mission/dto/ChallengeMissionStatusResponse.java
+++ b/motionit/src/main/java/com/back/motionit/domain/challenge/mission/dto/ChallengeMissionStatusResponse.java
@@ -6,14 +6,12 @@ import com.back.motionit.domain.challenge.mission.entity.ChallengeMissionStatus;
 
 public record ChallengeMissionStatusResponse(
 	Long participantId,
-	Long videoId,
 	LocalDate missionDate,
 	boolean completed
 ) {
 	public static ChallengeMissionStatusResponse from(ChallengeMissionStatus status) {
 		return new ChallengeMissionStatusResponse(
 			status.getParticipant().getId(),
-			status.getVideo() != null ? status.getVideo().getId() : null,
 			status.getMissionDate(),
 			status.getCompleted()
 		);

--- a/motionit/src/main/java/com/back/motionit/domain/challenge/mission/entity/ChallengeMissionStatus.java
+++ b/motionit/src/main/java/com/back/motionit/domain/challenge/mission/entity/ChallengeMissionStatus.java
@@ -3,7 +3,6 @@ package com.back.motionit.domain.challenge.mission.entity;
 import java.time.LocalDate;
 
 import com.back.motionit.domain.challenge.participant.entity.ChallengeParticipant;
-import com.back.motionit.domain.challenge.video.entity.ChallengeVideo;
 import com.back.motionit.global.jpa.entity.BaseEntity;
 
 import jakarta.persistence.Column;
@@ -27,7 +26,7 @@ import lombok.NoArgsConstructor;
 @Table(
 	name = "challenge_mission_status",
 	uniqueConstraints = {
-		@UniqueConstraint(columnNames = {"participant_id", "mission_date", "video_id"})
+		@UniqueConstraint(columnNames = {"participant_id", "mission_date"})
 	}
 )
 public class ChallengeMissionStatus extends BaseEntity {
@@ -35,11 +34,6 @@ public class ChallengeMissionStatus extends BaseEntity {
 	@ManyToOne(fetch = FetchType.LAZY, optional = false)
 	@JoinColumn(name = "participant_id", nullable = false)
 	private ChallengeParticipant participant;
-
-	// 어떤 영상에 대한 기록인지 (optional — 하루 1영상일 경우 null 가능)
-	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "video_id")
-	private ChallengeVideo video;
 
 	// 해당 미션 날짜
 	@Column(name = "mission_date", nullable = false)
@@ -49,9 +43,14 @@ public class ChallengeMissionStatus extends BaseEntity {
 	@Column(nullable = false)
 	private Boolean completed;
 
+	public ChallengeMissionStatus(ChallengeParticipant participant, LocalDate today) {
+		this.participant = participant;
+		this.missionDate = today;
+		this.completed = false;
+	}
+
 	// 미션 완료 처리 메서드
-	public void completeMission(ChallengeVideo video) {
+	public void completeMission() {
 		this.completed = true;
-		this.video = video;
 	}
 }

--- a/motionit/src/main/java/com/back/motionit/domain/challenge/video/repository/ChallengeVideoRepository.java
+++ b/motionit/src/main/java/com/back/motionit/domain/challenge/video/repository/ChallengeVideoRepository.java
@@ -19,4 +19,6 @@ public interface ChallengeVideoRepository extends JpaRepository<ChallengeVideo, 
 	Optional<ChallengeVideo> findByIdAndUserId(Long videoId, Long userId);
 
 	Collection<ChallengeVideo> findByChallengeRoomId(Long roomId);
+
+	boolean existsByChallengeRoomIdAndUploadDate(Long roomId, LocalDate today);
 }

--- a/motionit/src/main/java/com/back/motionit/global/error/code/ChallengeMissionErrorCode.java
+++ b/motionit/src/main/java/com/back/motionit/global/error/code/ChallengeMissionErrorCode.java
@@ -12,7 +12,8 @@ public enum ChallengeMissionErrorCode implements ErrorCode {
 	NOT_FOUND_VIDEO(HttpStatus.NOT_FOUND, "R-701", "챌린지 영상을 찾을 수 없습니다."),
 	NOT_INITIALIZED_MISSION(HttpStatus.BAD_REQUEST, "R-702", "오늘의 미션이 초기화되지 않았습니다."),
 	INVALID_ROOM_ACCESS(HttpStatus.FORBIDDEN, "R-703", "챌린지 방에 접근할 수 없습니다."),
-	ALREADY_COMPLETED(HttpStatus.BAD_REQUEST, "R-704", "오늘의 미션을 이미 완료했습니다.");
+	ALREADY_COMPLETED(HttpStatus.BAD_REQUEST, "R-704", "오늘의 미션을 이미 완료했습니다."),
+	NO_VIDEO_UPLOADED(HttpStatus.BAD_REQUEST, "R-705", "완료할 오늘이 미션이 등록되지 않았습니다.");
 
 	private final HttpStatus status;
 	private final String code;

--- a/motionit/src/main/java/com/back/motionit/global/init/DataInitializer.java
+++ b/motionit/src/main/java/com/back/motionit/global/init/DataInitializer.java
@@ -139,7 +139,6 @@ public class DataInitializer {
 
 			missionStatuses.add(new ChallengeMissionStatus(
 				hostParticipant,
-				todayVideo,
 				LocalDate.now(),
 				true
 			));
@@ -148,7 +147,6 @@ public class DataInitializer {
 				boolean completed = new Random().nextBoolean();
 				missionStatuses.add(new ChallengeMissionStatus(
 					p,
-					completed ? todayVideo : null,
 					LocalDate.now(),
 					completed
 				));

--- a/motionit/src/main/java/com/back/motionit/global/respoonsedata/ResponseData.java
+++ b/motionit/src/main/java/com/back/motionit/global/respoonsedata/ResponseData.java
@@ -38,7 +38,18 @@ public class ResponseData<T> {
 
 	@JsonIgnore
 	public int getStatusCode() {
-		String statusCode = resultCode.split("-")[1];
-		return Integer.parseInt(statusCode);
+		if (resultCode == null)
+			return 500;
+
+		try {
+			if (resultCode.contains("-")) {
+				String[] parts = resultCode.split("-");
+				return Integer.parseInt(parts[1]);
+			}
+			// 숫자 형태라면 그대로 반환
+			return Integer.parseInt(resultCode);
+		} catch (Exception e) {
+			return 500; // fallback
+		}
 	}
 }

--- a/motionit/src/test/java/com/back/motionit/domain/challenge/missionstatus/controller/ChallengeMissionsStatusControllerTest.java
+++ b/motionit/src/test/java/com/back/motionit/domain/challenge/missionstatus/controller/ChallengeMissionsStatusControllerTest.java
@@ -125,7 +125,7 @@ public class ChallengeMissionsStatusControllerTest {
 	void completeMission_alreadyCompleted() throws Exception {
 		ChallengeMissionStatus mission = challengeMissionStatusRepository.findByParticipantIdAndMissionDate(
 			participant.getId(), today).get();
-		mission.completeMission(video);
+		mission.completeMission();
 		challengeMissionStatusRepository.save(mission);
 
 		ChallengeMissionCompleteRequest request =


### PR DESCRIPTION
<!--
  템플릿은 아직 PR 작성이 익숙하지 않으신 분들을 위해서 제공하는 가이드입니다!
  리뷰어 또는 이 PR을 보게 될 다른 사람들이 이 PR을 보는데 참고할 수 있는 내용이 있다면 포함해서 작성해주시면 됩니다.
-->

## 관련 이슈

- Close #89 

## PR / 과제 설명 

기존 미션 완료 처리에는 Video가 필요했으나, 현 요구사항에서 요구하는 바에 따르면 영상이 몇 개가 있는지 여부와는 무관하게 완료처리가 가능함.

- 이에 따라 불필요한 연관관계를 제거
- 요구사항에 맞는 더 자연스러운 응답구조로 개선
- 이에 더해 미션 완료처리에 있어 신규 참여자는 당일 미션 테이블을 스케줄러가 초기화해주는 다음날까지 미션 완료처리가 불가했던 제약사항도 부자연스러워 개선 / 스케줄러 예외처리 추가
- ResponseData 응답구조 개선
