### PR TITLE
욕설 필터링(AI없이 정규화+키워드) 구현 

### DIFF
--- a/motionit/src/main/java/com/back/motionit/domain/challenge/comment/entity/Comment.java
+++ b/motionit/src/main/java/com/back/motionit/domain/challenge/comment/entity/Comment.java
@@ -48,10 +48,6 @@ public class Comment extends BaseEntity {
 	private String content;
 
 	@Builder.Default
-	@Column(name = "is_deleted", nullable = false)
-	private boolean deleted=false;
-
-	@Builder.Default
 	@Column(name = "like_count", nullable = false, columnDefinition = "INT DEFAULT 0")
 	private Integer likeCount=0;
 
@@ -67,6 +63,6 @@ public class Comment extends BaseEntity {
 		return deletedAt != null;
 	}
 	public void restore() {
-		this.deleted = false;
+		this.deletedAt = null;
 	}
 }

--- a/motionit/src/main/java/com/back/motionit/domain/challenge/comment/moderation/CommentModeration.java
+++ b/motionit/src/main/java/com/back/motionit/domain/challenge/comment/moderation/CommentModeration.java
@@ -1,0 +1,20 @@
+package com.back.motionit.domain.challenge.comment.moderation;
+
+import org.springframework.stereotype.Component;
+
+import com.back.motionit.global.error.code.CommentErrorCode;
+import com.back.motionit.global.error.exception.BusinessException;
+
+@Component
+public class CommentModeration {
+
+	public void assertClean(String content) {
+		KeywordFilter.Decision d = KeywordFilter.decide(content);
+
+		switch (d) {
+			case BLOCK -> throw new BusinessException(CommentErrorCode.INAPPROPRIATE_CONTENT_BLOCK);
+			case WARN  -> throw new BusinessException(CommentErrorCode.INAPPROPRIATE_CONTENT_WARN);
+			case ALLOW -> { /* 통과 */ }
+		}
+	}
+}

--- a/motionit/src/main/java/com/back/motionit/domain/challenge/comment/moderation/KeywordFilter.java
+++ b/motionit/src/main/java/com/back/motionit/domain/challenge/comment/moderation/KeywordFilter.java
@@ -1,0 +1,54 @@
+package com.back.motionit.domain.challenge.comment.moderation;
+
+import java.util.List;
+
+public class KeywordFilter {
+
+	public enum Decision { ALLOW, WARN, BLOCK }
+
+	// 오탐 방지
+	private static final List<String> WHITELIST = List.of(
+		"시발점","병신도","꺼져가", "꺼져감", "보지말","보지않","보지못","보지마","자지말",
+		 "자지않","자지못","자지마","자지러","2018년",
+		"Scunthorpe"
+
+	);
+
+
+	private static final List<String> BLOCK = List.of(
+		"씨발", "ㅆㅣ발", "씹팔", "좆", "존나", "병신", "븅신", "ㅄ",
+		"지랄", "지럴", "개새끼", "개새", "개자식", "개지랄", "꺼져",
+		"꺼져라", "꺼져버려", "뒤져", "뒤져라", "죽여","죽일놈", "죽어라", "18새끼",
+		"18년", "18놈", "18것", "십팔", "시팔", "씨팔", "씹년", "씹놈", "씹새끼", "쌍년",
+		"쌍놈", "썅", "좆같", "좆나","좆밥", "좆", "미친년", "미친놈"
+		, "쓰레기같은", "창녀", "창년", "강간", "느금마","자지","보지","씨발","씨발년","새끼","병신","좆밥","1찍","2찍","좆물", "걸레년", "년놈",
+		"딸딸이", "빨갱이", "토착왜구", "수구꼴통", "문빠", "벌레새끼","일베충","펨코충","죽여버려", "목잘라", "찌른다", "칼부림",
+		"게이새끼","게이년", "병신", "메갈","시발","시바라","씨바","시바","찔러","등신","시발",
+		"motherfucker", "nigger","faggot", "cunt","slut","whore","dick","pussy","retard"
+	);
+
+
+	private static final List<String> WARN = List.of(
+		"ㅅㅂ", "ㅆㅂ", "ㅈㄴ", "ㅈ나", "ㅈㄹ", "ㅁㅊ", "개극혐",
+		"극혐", "정신병자",  "돌았냐","돌았네", "ㅂㅅ", "ㅗ",
+		"ㄲㅈ", "ㅉㅉ", "ㅆㄹㄱ", "ㅅㄲ", "ㅈㄹㄴ", "ㄱㅅㄲ", "ㄱㅅㄴ", "ㄴㄱㅈ", "ㄷㅈ",
+		"ㄷㅊ", "ㅅㅂㄹㅁ", "ㅆㅂㄴ", "ㅂㅅ같", "ㅈㄴ웃김", "병맛", "급식충", "틀딱","꼰대",
+		 "멍청", "저능", "쪼다", "개씹", "미친놈","또라이","돌아이","애미","애비","영포티","영써티","호구","꼴리",
+		"대깨문", "윤찌끄레기", "문슬람", "국짐", "보수꼰대","패버려", "죽인다", "남혐", "여혐", "장애있","틀딱",
+		"bitch","asshole","shit","fuck","crap","loser","dumb","idiot"
+	);
+
+	public static Decision decide(String raw) {
+		String n = NormLite.normalize(raw);
+
+		for (String w : WHITELIST) {
+			n = n.replace(w, "");
+		}
+
+		for (String b : BLOCK) if (n.contains(b)) return Decision.BLOCK;
+
+		for (String w : WARN)  if (n.contains(w)) return Decision.WARN;
+
+		return Decision.ALLOW;
+	}
+}

--- a/motionit/src/main/java/com/back/motionit/domain/challenge/comment/moderation/NormLite.java
+++ b/motionit/src/main/java/com/back/motionit/domain/challenge/comment/moderation/NormLite.java
@@ -1,0 +1,64 @@
+package com.back.motionit.domain.challenge.comment.moderation;
+
+import java.text.Normalizer;
+import java.util.HashMap;
+import java.util.Map;
+
+public class NormLite {
+
+
+	private static final Map<Integer, Character> JAMO_TO_COMPAT = new HashMap<>();
+	static {
+		JAMO_TO_COMPAT.put(0x1100, 'ㄱ'); // ᄀ -> ㄱ
+		JAMO_TO_COMPAT.put(0x1101, 'ㄲ'); // ᄁ -> ㄲ
+		JAMO_TO_COMPAT.put(0x1102, 'ㄴ'); // ᄂ -> ㄴ
+		JAMO_TO_COMPAT.put(0x1103, 'ㄷ'); // ᄃ -> ㄷ
+		JAMO_TO_COMPAT.put(0x1104, 'ㄸ'); // ᄄ -> ㄸ
+		JAMO_TO_COMPAT.put(0x1105, 'ㄹ'); // ᄅ -> ㄹ
+		JAMO_TO_COMPAT.put(0x1106, 'ㅁ'); // ᄆ -> ㅁ
+		JAMO_TO_COMPAT.put(0x1107, 'ㅂ'); // ᄇ -> ㅂ
+		JAMO_TO_COMPAT.put(0x1108, 'ㅃ'); // ᄈ -> ㅃ
+		JAMO_TO_COMPAT.put(0x1109, 'ㅅ'); // ᄉ -> ㅅ
+		JAMO_TO_COMPAT.put(0x110A, 'ㅆ'); // ᄊ -> ㅆ
+		JAMO_TO_COMPAT.put(0x110B, 'ㅇ'); // ᄋ -> ㅇ
+		JAMO_TO_COMPAT.put(0x110C, 'ㅈ'); // ᄌ -> ㅈ
+		JAMO_TO_COMPAT.put(0x110D, 'ㅉ'); // ᄍ -> ㅉ
+		JAMO_TO_COMPAT.put(0x110E, 'ㅊ'); // ᄎ -> ㅊ
+		JAMO_TO_COMPAT.put(0x110F, 'ㅋ'); // ᄏ -> ㅋ
+		JAMO_TO_COMPAT.put(0x1110, 'ㅌ'); // ᄐ -> ㅌ
+		JAMO_TO_COMPAT.put(0x1111, 'ㅍ'); // ᄑ -> ㅍ
+		JAMO_TO_COMPAT.put(0x1112, 'ㅎ'); // ᄒ -> ㅎ
+	}
+
+	private static String toCompatJamo(String s) {
+		StringBuilder sb = new StringBuilder();
+		for (int i = 0; i < s.length(); ) {
+			int cp = s.codePointAt(i);
+			i += Character.charCount(cp);
+			Character mapped = JAMO_TO_COMPAT.get(cp);
+			if (mapped != null) sb.append(mapped);
+			else sb.appendCodePoint(cp);
+		}
+		return sb.toString();
+	}
+
+	public static String normalize(String raw) {
+		if (raw == null) return "";
+		String s = Normalizer.normalize(raw, Normalizer.Form.NFKC).toLowerCase();
+
+
+		s = s.replaceAll("[\\u200B-\\u200D\\uFEFF]", "");
+
+		//초성 자모(ᄉ,ᄇ 등)를 호환 자모(ㅅ,ㅂ)로 되돌리기
+		s = toCompatJamo(s);
+
+		s = s.replaceAll("(?<=[가-힣])[1lI|]+(?=[가-힣])", "");
+
+		s = s.replaceAll("[._\\-/,\\s]+", "");
+
+
+		s = s.replaceAll("(.)\\1{3,}", "$1$1");
+
+		return s.trim();
+	}
+}

--- a/motionit/src/main/java/com/back/motionit/domain/challenge/comment/service/CommentService.java
+++ b/motionit/src/main/java/com/back/motionit/domain/challenge/comment/service/CommentService.java
@@ -10,6 +10,7 @@ import com.back.motionit.domain.challenge.comment.dto.CommentCreateReq;
 import com.back.motionit.domain.challenge.comment.dto.CommentEditReq;
 import com.back.motionit.domain.challenge.comment.dto.CommentRes;
 import com.back.motionit.domain.challenge.comment.entity.Comment;
+import com.back.motionit.domain.challenge.comment.moderation.CommentModeration;
 import com.back.motionit.domain.challenge.comment.repository.CommentRepository;
 import com.back.motionit.domain.challenge.room.entity.ChallengeRoom;
 import com.back.motionit.domain.challenge.room.repository.ChallengeRoomRepository;
@@ -29,10 +30,11 @@ public class CommentService {
 	private final ChallengeRoomRepository challengeRoomRepository;
 	private final UserRepository userRepository;
 	private final ChallengeRoomService challengeRoomService;
+	private final CommentModeration commentModeration;
 
 	@Transactional
 	public CommentRes create(Long roomId, Long userId, CommentCreateReq req) {
-
+		commentModeration.assertClean(req.content());
 		ChallengeRoom room = challengeRoomRepository.findById(roomId)
 			.orElseThrow(() -> new BusinessException(CommentErrorCode.ROOM_NOT_FOUND));
 		User author = userRepository.findById(userId)
@@ -60,10 +62,11 @@ public class CommentService {
 	@Transactional
 	public CommentRes edit(Long roomId, Long commentId, Long userId, CommentEditReq req) {
 
+		commentModeration.assertClean(req.content());
 		Comment c = commentRepository.findByIdAndChallengeRoom_Id(commentId, roomId)
 			.orElseThrow(() -> new BusinessException(CommentErrorCode.COMMENT_NOT_FOUND));
 
-		// 작성자 본인만
+
 		if (!c.getUser().getId().equals(userId)) {
 			throw new BusinessException(CommentErrorCode.WRONG_ACCESS);
 		}

--- a/motionit/src/main/java/com/back/motionit/global/error/code/CommentErrorCode.java
+++ b/motionit/src/main/java/com/back/motionit/global/error/code/CommentErrorCode.java
@@ -12,7 +12,11 @@ public enum CommentErrorCode implements ErrorCode {
 	WRONG_ACCESS(HttpStatus.FORBIDDEN, "M-101", "본인이 작성한 댓글이 아닙니다."),
 	COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "M-102", "댓글을 찾을 수 없습니다."),
 	ROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "M-103", "운동방을 찾을 수 없습니다."),
-	USER_NOT_FOUND(HttpStatus.NOT_FOUND, "M-104", "사용자를 찾을 수 없습니다.");
+	USER_NOT_FOUND(HttpStatus.NOT_FOUND, "M-104", "사용자를 찾을 수 없습니다."),
+	INAPPROPRIATE_CONTENT_WARN(HttpStatus.UNPROCESSABLE_ENTITY, "M-105",
+		"공격적으로 인식될 수 있습니다. 완화된 표현으로 다시 작성해 주세요."),
+	INAPPROPRIATE_CONTENT_BLOCK(HttpStatus.FORBIDDEN, "M-106",
+		"강한 욕설이나 비하 표현은 허용되지 않습니다.");
 	private final HttpStatus status;
 	private final String code;
 	private final String message;

--- a/motionit/src/test/java/com/back/motionit/domain/challenge/comment/moderation/CommentModerationTest.java
+++ b/motionit/src/test/java/com/back/motionit/domain/challenge/comment/moderation/CommentModerationTest.java
@@ -1,0 +1,34 @@
+package com.back.motionit.domain.challenge.comment.moderation;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.back.motionit.global.error.code.CommentErrorCode;
+import com.back.motionit.global.error.exception.BusinessException;
+
+class CommentModerationTest {
+
+	CommentModeration moderation = new CommentModeration();
+
+	@Test @DisplayName("BLOCK이면 INAPPROPRIATE_CONTENT_BLOCK 예외")
+	void assertClean_block() {
+		assertThatThrownBy(() -> moderation.assertClean("병신"))
+			.isInstanceOf(BusinessException.class)
+			.hasMessageContaining(CommentErrorCode.INAPPROPRIATE_CONTENT_BLOCK.getMessage());
+	}
+
+	@Test @DisplayName("WARN이면 INAPPROPRIATE_CONTENT_WARN 예외")
+	void assertClean_warn() {
+		assertThatThrownBy(() -> moderation.assertClean("틀딱"))
+			.isInstanceOf(BusinessException.class)
+			.hasMessageContaining(CommentErrorCode.INAPPROPRIATE_CONTENT_WARN.getMessage());
+	}
+
+	@Test @DisplayName("ALLOW면 예외 없음")
+	void assertClean_allow() {
+		moderation.assertClean("시발점 찾는 법 안내"); // 통과
+	}
+
+}

--- a/motionit/src/test/java/com/back/motionit/domain/challenge/comment/moderation/KeywordFilterTest.java
+++ b/motionit/src/test/java/com/back/motionit/domain/challenge/comment/moderation/KeywordFilterTest.java
@@ -1,0 +1,100 @@
+package com.back.motionit.domain.challenge.comment.moderation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class KeywordFilterTest {
+
+	// ---------------- BLOCK ----------------
+
+	@Test
+	@DisplayName("BLOCK: 강한 욕설은 차단된다(씨발/시발/18/개새끼 등)")
+	void block_basic() {
+		// 점/공백 제거 후 '씨발' 매칭
+		assertThat(KeywordFilter.decide("스쿼트 그렇게 하는 거 아니라고 씨 바..."))
+			.isEqualTo(KeywordFilter.Decision.BLOCK);
+
+		// 시발 계열은 BLOCK 리스트에 포함되어야 함
+		assertThat(KeywordFilter.decide("시발 뭐함?"))
+			.isEqualTo(KeywordFilter.Decision.BLOCK);
+		assertThat(KeywordFilter.decide("시.발 같은 소리"))
+			.isEqualTo(KeywordFilter.Decision.BLOCK);
+		assertThat(KeywordFilter.decide("시바라 진짜"))
+			.isEqualTo(KeywordFilter.Decision.BLOCK);
+		assertThat(KeywordFilter.decide("씨1바 그만해"))
+			.isEqualTo(KeywordFilter.Decision.BLOCK);
+
+		// 숫자형 욕설
+		assertThat(KeywordFilter.decide("개 못해 18놈아"))
+			.isEqualTo(KeywordFilter.Decision.BLOCK);
+
+
+		assertThat(KeywordFilter.decide("그따구로 할거면 때려쳐 등 신아"))
+			.isEqualTo(KeywordFilter.Decision.BLOCK);
+		assertThat(KeywordFilter.decide("mother_fucker"))
+			.isEqualTo(KeywordFilter.Decision.BLOCK);
+	}
+
+	@Test
+	@DisplayName("BLOCK: 화이트리스트 마스킹 후 남은 욕설은 차단")
+	void block_after_whitelist_mask() {
+		// '병신도'는 제거되지만 뒤의 '시발'은 BLOCK
+		assertThat(KeywordFilter.decide("병신도부터 문제였어 시발"))
+			.isEqualTo(KeywordFilter.Decision.BLOCK);
+
+
+		assertThat(KeywordFilter.decide("보지못한게 자랑이냐 등신아?"))
+			.isEqualTo(KeywordFilter.Decision.BLOCK);
+	}
+
+	// ---------------- WARN ----------------
+
+	@Test
+	@DisplayName("WARN: 축약/약한 욕설은 경고된다(돌았네, 정신병자, ㅈㄹㄴ 등)")
+	void warn_basic() {
+		assertThat(KeywordFilter.decide("idiot"))
+			.isEqualTo(KeywordFilter.Decision.WARN);
+
+		assertThat(KeywordFilter.decide("운동 강도 진짜 돌았네"))
+			.isEqualTo(KeywordFilter.Decision.WARN);
+
+		assertThat(KeywordFilter.decide("정신병자세요?"))
+			.isEqualTo(KeywordFilter.Decision.WARN);
+	}
+
+	// ---------------- ALLOW ----------------
+
+	@Test
+	@DisplayName("ALLOW: 화이트리스트 단어만 있을 때는 통과된다")
+	void whitelist_allow_only() {
+		assertThat(KeywordFilter.decide("시발점 찾는 법 설명"))
+			.isEqualTo(KeywordFilter.Decision.ALLOW);
+
+		assertThat(KeywordFilter.decide("보지말다 자지러지다 보지않다 꺼져가다"))
+			.isEqualTo(KeywordFilter.Decision.ALLOW);
+
+		assertThat(KeywordFilter.decide("보지마 자지마"))
+			.isEqualTo(KeywordFilter.Decision.ALLOW);
+	}
+
+	@Test
+	@DisplayName("ALLOW: 화이트리스트가 포함되어도 욕설이 없으면 통과")
+	void whitelist_mixed_without_abuse() {
+		assertThat(KeywordFilter.decide("오랜시간 자지 않아서 머리가 안 돌아가"))
+			.isEqualTo(KeywordFilter.Decision.ALLOW);
+	}
+
+	// ---------------- COMBO ----------------
+
+	@Test
+	@DisplayName("COMBO: 화이트리스트 + 욕설 동시 포함 시 욕설이 우선한다")
+	void whitelist_plus_abuse() {
+		assertThat(KeywordFilter.decide("자지러졌어 이 새끼야"))
+			.isEqualTo(KeywordFilter.Decision.BLOCK);
+
+		assertThat(KeywordFilter.decide("보지않았어 그래서 멍청이가 됐어"))
+			.isEqualTo(KeywordFilter.Decision.WARN);
+	}
+}

--- a/motionit/src/test/java/com/back/motionit/domain/challenge/comment/moderation/NormLiteTest.java
+++ b/motionit/src/test/java/com/back/motionit/domain/challenge/comment/moderation/NormLiteTest.java
@@ -1,0 +1,42 @@
+package com.back.motionit.domain.challenge.comment.moderation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class NormLiteTest {
+
+	@Test
+	@DisplayName("점/공백/기호 제거")
+	void removePunctuationsAndSpaces() {
+		assertThat(NormLite.normalize("씨...발 뭐하냐")).isEqualTo("씨발뭐하냐");
+		assertThat(NormLite.normalize("시. 발  같은 소리")).isEqualTo("시발같은소리");
+		assertThat(NormLite.normalize("개_새_ 끼")).isEqualTo("개새끼");
+		assertThat(NormLite.normalize("ㅅ-ㅂ_ 이건 좀")).isEqualTo("ㅅㅂ이건좀");
+		assertThat(NormLite.normalize("시1발아")).isEqualTo("시발아");
+	}
+
+	@Test
+	@DisplayName("제로폭 문자 제거")
+	void removeZeroWidth() {
+		String withZw = "ㅅ\u200Bㅂ 이건\u200D 좀\uFEFF";
+		assertThat(NormLite.normalize(withZw)).isEqualTo("ㅅㅂ이건좀");
+	}
+
+	@Test
+	@DisplayName("과도한 반복 축소(4회 이상 → 2회)")
+	void shrinkRepetitions() {
+		assertThat(NormLite.normalize("ㅋㅋㅋㅋㅋㅋ")).isEqualTo("ㅋㅋ");
+		assertThat(NormLite.normalize("와아아아아아아아아아아")).isEqualTo("와아아");
+	}
+
+	@Test
+	@DisplayName("NFKC + 소문자화 동작")
+	void nfkcAndLowercase() {
+		// 전각 -> 반각, 대문자 -> 소문자
+		assertThat(NormLite.normalize("ＳＩＢＡＬ")).isEqualTo("sibal");
+		// 섞여 있어도 정상 동작해야 함
+		assertThat(NormLite.normalize("Si.Bal")).isEqualTo("sibal");
+	}
+}

--- a/motionit/src/test/java/com/back/motionit/domain/challenge/comment/service/CommentServiceTest.java
+++ b/motionit/src/test/java/com/back/motionit/domain/challenge/comment/service/CommentServiceTest.java
@@ -1,0 +1,132 @@
+package com.back.motionit.domain.challenge.comment.service;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.back.motionit.domain.challenge.comment.dto.CommentCreateReq;
+import com.back.motionit.domain.challenge.comment.dto.CommentEditReq;
+import com.back.motionit.domain.challenge.comment.entity.Comment;
+import com.back.motionit.domain.challenge.comment.moderation.CommentModeration;
+import com.back.motionit.domain.challenge.comment.repository.CommentRepository;
+import com.back.motionit.domain.challenge.room.entity.ChallengeRoom;
+import com.back.motionit.domain.challenge.room.repository.ChallengeRoomRepository;
+import com.back.motionit.domain.challenge.room.service.ChallengeRoomService;
+import com.back.motionit.domain.user.entity.User;
+import com.back.motionit.domain.user.repository.UserRepository;
+import com.back.motionit.global.error.exception.BusinessException;
+
+class CommentServiceTest {
+
+	CommentRepository commentRepository = mock(CommentRepository.class);
+	ChallengeRoomRepository challengeRoomRepository = mock(ChallengeRoomRepository.class);
+	UserRepository userRepository = mock(UserRepository.class);
+	ChallengeRoomService challengeRoomService = mock(ChallengeRoomService.class);
+	CommentModeration commentModeration = new CommentModeration();
+
+	CommentService service;
+
+	@BeforeEach
+	void setUp() {
+		service = new CommentService(
+			commentRepository, challengeRoomRepository, userRepository, challengeRoomService, commentModeration
+		);
+	}
+
+	@Test
+	@DisplayName("create: BLOCK이면 저장 로직까지 가지 않고 예외")
+	void create_block_stops_early() {
+		Long roomId = 1L; Long userId = 1L;
+
+
+		ChallengeRoom room = mock(ChallengeRoom.class);
+		User author = mock(User.class);
+
+		when(challengeRoomRepository.findById(roomId)).thenReturn(Optional.of(room));
+		when(userRepository.findById(userId)).thenReturn(Optional.of(author));
+
+		var req = new CommentCreateReq("움직임이 너무 븅1신같으세요ㅋㅋ"); // BLOCK
+
+		assertThatThrownBy(() -> service.create(roomId, userId, req))
+			.isInstanceOf(BusinessException.class);
+
+
+		verify(commentRepository, never()).save(any(Comment.class));
+	}
+
+	@Test
+	@DisplayName("create: ALLOW면 정상 저장 로직 호출")
+	void create_allow_saves() {
+		Long roomId = 1L; Long userId = 1L;
+
+		ChallengeRoom room = mock(ChallengeRoom.class);
+		User author = mock(User.class);
+
+		when(challengeRoomRepository.findById(roomId)).thenReturn(Optional.of(room));
+		when(userRepository.findById(userId)).thenReturn(Optional.of(author));
+
+		when(commentRepository.save(any(Comment.class))).thenAnswer(inv -> inv.getArgument(0));
+
+		var req = new CommentCreateReq("2012년의 교통사고가 허리디스크 문제의 시발점이었습니다."); // ALLOW
+
+		service.create(roomId, userId, req);
+
+		verify(commentRepository, times(1)).save(any(Comment.class));
+	}
+
+	@Test
+	@DisplayName("edit: 작성자 본인 + WARN이면 예외 발생, 내용 변경 안 됨")
+	void edit_warn_throws() {
+		Long roomId = 10L; Long commentId = 20L; Long userId = 99L;
+
+
+		User author = mock(User.class);
+		when(author.getId()).thenReturn(userId);
+
+		ChallengeRoom room = mock(ChallengeRoom.class);
+
+		Comment comment = mock(Comment.class);
+		when(comment.getUser()).thenReturn(author);
+		when(comment.getChallengeRoom()).thenReturn(room);
+
+		when(commentRepository.findByIdAndChallengeRoom_Id(commentId, roomId))
+			.thenReturn(Optional.of(comment));
+
+		var req = new CommentEditReq("말을 왜 그렇게 하세요? 정신병자세요?"); // WARN
+
+		assertThatThrownBy(() -> service.edit(roomId, commentId, userId, req))
+			.isInstanceOf(BusinessException.class);
+
+
+		verify(comment, never()).edit(anyString());
+	}
+
+	@Test
+	@DisplayName("edit: 작성자 본인 + ALLOW면 내용 변경 호출")
+	void edit_allow_updates() {
+		Long roomId = 10L; Long commentId = 20L; Long userId = 99L;
+
+		User author = mock(User.class);
+		when(author.getId()).thenReturn(userId);
+
+		ChallengeRoom room = mock(ChallengeRoom.class);
+
+		Comment comment = mock(Comment.class);
+		when(comment.getUser()).thenReturn(author);
+		when(comment.getChallengeRoom()).thenReturn(room);
+
+		when(commentRepository.findByIdAndChallengeRoom_Id(commentId, roomId))
+			.thenReturn(Optional.of(comment));
+
+		var req = new CommentEditReq("병신도라는 불교용어가 있습니다."); // ALLOW
+
+		service.edit(roomId, commentId, userId, req);
+
+		verify(comment, times(1)).edit("병신도라는 불교용어가 있습니다.");
+	}
+}


### PR DESCRIPTION
## 관련 이슈

- Close #66 

## PR / 과제 설명 
댓글 작성 시 비속어를 자동 감지하고 차단하는 욕설 필터링 기능 추가

MVP 버전으로 외부 API(Perspective API 등)는 사용하지 않고 정규화(공백, 점, 숫자 제거 등) + 키워드(욕설 단어) 매칭 기반 로컬 필터링 구현. 
Comment entity 중복된 딜리트 코드 삭제

⚙️ 주요 구현 내용
1.NormLite

입력 문장을 NFKC 정규화 후,

점(.), 공백, 하이픈 등 교란 문자와 제로폭 문자 제거

초성 자모(ᄉᄇ)를 호환 자모(ㅅㅂ)로 통일

숫자·문자 교란(시1발, 시|발, si..bal) 패턴을 정규화하여 탐지 강화

반복 문자 축소 (ㅋㅋㅋㅋ → ㅋㅋ)

2. KeywordFilter

BLOCK, WARN, WHITELIST 세 가지 수준의 리스트를 구성

화이트리스트 단어(예: 시발점, 자지러지다)를 우선 제거하여 오탐 방지

BLOCK → 즉시 차단, WARN → 경고 수준으로 구분(현재는 MVP로 WARN도 댓글 생성이 막히지만 추가 기능에선 한 번의 경고 후 작성 가능하게 변경 예정)

KeywordFilter.Decision(ALLOW, WARN, BLOCK) 구조로 결과 리턴

3. CommentModeration

댓글 생성/수정 시 KeywordFilter.decide() 호출

BLOCK → INAPPROPRIATE_CONTENT(B-401) 예외 발생

WARN → INAPPROPRIATE_CONTENT_WARN(B-402) 예외 발생

ALLOW → 통과

4. 부적절한 표현 에러코드 추가

5. CommentService에 생성, 수정에 commentModeration.assertClean(req.content()); 한 줄씩 추가

6. 테스트 (KeywordFilterTest, NormLiteTest, CommentModerationTest, CommentServiceTest)

강한 욕설, 약한 욕설, 화이트리스트, 교란 문자(“시1발”, “시|발”, “시8발”) 등 총 20여 개 케이스 작성

단위 테스트 통과 


7. Comment entity 중복된 딜리트 코드 삭제
