### PR TITLE
댓글 프론트 반영, 인증인가-응답구조 일부 개선

### DIFF
--- a/frontend/motionit/src/app/rooms/[roomId]/page.tsx
+++ b/frontend/motionit/src/app/rooms/[roomId]/page.tsx
@@ -4,7 +4,7 @@ import { useParams, useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 import { challengeService } from "@/services";
 import type { ChallengeVideo, ChallengeMissionStatus } from "@/type";
-import { UploadVideoForm, VideoItem } from "@/components";
+import { UploadVideoForm, VideoItem, CommentSection } from "@/components";
 
 export default function RoomDetailPage() {
   const params = useParams();
@@ -181,6 +181,8 @@ export default function RoomDetailPage() {
               {missionStatus}
             </p>
           )}
+          {/* 댓글 섹션 */}
+          <CommentSection roomId={roomId} />
         </div>
       )}
 

--- a/frontend/motionit/src/components/index.tsx
+++ b/frontend/motionit/src/components/index.tsx
@@ -1,2 +1,3 @@
 export { default as UploadVideoForm } from "../components/UploadVideoForm";
 export { default as VideoItem } from "../components/VideoItem";
+export { default as CommentSection } from "../components/CommentSection";

--- a/frontend/motionit/src/constants/challenge.constant.ts
+++ b/frontend/motionit/src/constants/challenge.constant.ts
@@ -5,4 +5,12 @@ export const CHALLENGE_API = {
   COMPLETE_MISSION: (roomId: number) => `/api/v1/challenge/rooms/${roomId}/missions/complete`,
   GET_TODAY_MISSIONS: (roomId: number) => `/api/v1/challenge/rooms/${roomId}/missions/today`,
   LEAVE_ROOM: (roomId: number) => `/api/v1/challenge/participants/${roomId}/leave`,
+  GET_PARTICIPATION_STATUS: (roomId: number) => `/api/v1/challenge/participants/${roomId}/status`,
+  GET_COMMENTS: (roomId: number, page = 0, size = 5) =>
+    `/api/v1/rooms/${roomId}/comments?page=${page}&size=${size}`,
+  CREATE_COMMENT: (roomId: number) => `/api/v1/rooms/${roomId}/comments`,
+  EDIT_COMMENT: (roomId: number, commentId: number) =>
+    `/api/v1/rooms/${roomId}/comments/${commentId}`,
+  DELETE_COMMENT: (roomId: number, commentId: number) =>
+    `/api/v1/rooms/${roomId}/comments/${commentId}`,
 };

--- a/frontend/motionit/src/services/challenge.service.ts
+++ b/frontend/motionit/src/services/challenge.service.ts
@@ -43,6 +43,41 @@ class ChallengeService {
       method: "POST",
     });
   }
+
+  // 운동방 참가자 여부 조회
+  getParticipationStatus(roomId: number) {
+    return fetchApi(CHALLENGE_API.GET_PARTICIPATION_STATUS(roomId));
+  }
+
+  // ✅ 댓글 목록 조회 (페이지네이션)
+  getComments(roomId: number, page = 0, size = 20) {
+    return fetchApi(CHALLENGE_API.GET_COMMENTS(roomId, page, size));
+  }
+
+  // ✅ 댓글 작성
+  createComment(roomId: number, content: string) {
+    return fetchApi(CHALLENGE_API.CREATE_COMMENT(roomId), {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ content }),
+    });
+  }
+
+  // ✅ 댓글 수정
+  editComment(roomId: number, commentId: number, content: string) {
+    return fetchApi(CHALLENGE_API.EDIT_COMMENT(roomId, commentId), {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ content }),
+    });
+  }
+
+  // ✅ 댓글 삭제
+  deleteComment(roomId: number, commentId: number) {
+    return fetchApi(CHALLENGE_API.DELETE_COMMENT(roomId, commentId), {
+      method: "DELETE",
+    });
+  }
 }
 
 export const challengeService = new ChallengeService();

--- a/frontend/motionit/src/services/client.ts
+++ b/frontend/motionit/src/services/client.ts
@@ -1,16 +1,30 @@
-export const fetchApi = (url: string, options?: RequestInit) => {
-    if (options?.body) {
-        const headers = new Headers(options.headers || {});
-        headers.set("Content-Type", "application/json");
-        options.headers = headers;
-    } 
+export const fetchApi = async (url: string, options?: RequestInit) => {
+    try {
+      const finalOptions: RequestInit = {
+        ...options,
+        credentials: "include", // 쿠키 자동 포함
+      };
 
-    return fetch(`${process.env.NEXT_PUBLIC_API_BASE_URL}${url}`, options).then( async (res) => {
-        if(!res.ok) {
-            const resultData = await res.json();
-            throw new Error(resultData.msg || "Failed Request");
-        }
+      if (finalOptions.body && !finalOptions.headers) {
+        finalOptions.headers = { "Content-Type": "application/json" };
+      }
 
-        return res.json();
-    });
-}
+      const fullUrl = `${process.env.NEXT_PUBLIC_API_BASE_URL}${url}`;
+      console.log("📡 Fetch 요청:", fullUrl, finalOptions);
+
+      const res = await fetch(fullUrl, finalOptions);
+
+      if (!res.ok) {
+        const resultData = await res.json().catch(() => ({}));
+        console.error("❌ Fetch 실패:", res.status, resultData);
+        throw new Error(resultData.msg || `HTTP ${res.status}`);
+      }
+
+      const data = await res.json();
+      console.log("✅ Fetch 성공:", data);
+      return data;
+    } catch (err) {
+      console.error("🔥 Fetch 예외:", err);
+      throw err;
+    }
+  };

--- a/frontend/motionit/src/type/roomdetail.type.ts
+++ b/frontend/motionit/src/type/roomdetail.type.ts
@@ -16,3 +16,21 @@ export interface ChallengeMissionStatus {
   completed: boolean;
   isHost: "HOST" | "MEMBER";
 }
+
+export interface ParticipationStatus {
+  userId: number;
+  roomId: number;
+  joined: boolean;
+}
+
+export interface Comment {
+  id: number;
+  roomId: number;
+  authorId: number;
+  authorNickname: string;
+  content: string;
+  deleted: boolean;
+  likeCount: number;
+  createdAt: string;
+  updatedAt: string;
+}

--- a/motionit/src/main/java/com/back/motionit/domain/challenge/comment/controller/CommentController.java
+++ b/motionit/src/main/java/com/back/motionit/domain/challenge/comment/controller/CommentController.java
@@ -1,7 +1,6 @@
 package com.back.motionit.domain.challenge.comment.controller;
 
 import org.springframework.data.domain.Page;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -16,6 +15,8 @@ import com.back.motionit.domain.challenge.comment.dto.CommentCreateReq;
 import com.back.motionit.domain.challenge.comment.dto.CommentEditReq;
 import com.back.motionit.domain.challenge.comment.dto.CommentRes;
 import com.back.motionit.domain.challenge.comment.service.CommentService;
+import com.back.motionit.domain.user.entity.User;
+import com.back.motionit.global.request.RequestContext;
 import com.back.motionit.global.respoonsedata.ResponseData;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -31,47 +32,44 @@ import lombok.RequiredArgsConstructor;
 public class CommentController {
 
 	private final CommentService commentService;
+	private final RequestContext requestContext;
 
 	@Operation(summary = "댓글 생성", description = "운동방에 댓글을 작성합니다.")
 	@PostMapping
 	public ResponseData<CommentRes> create(@PathVariable Long roomId,
-		@AuthenticationPrincipal Object authUser,
 		@Valid @RequestBody CommentCreateReq req) {
-		Long userId = extractUserId(authUser);
-		CommentRes res = commentService.create(roomId, userId, req);
-		return ResponseData.success("201-0", "created", res);
+		User actor = requestContext.getActor();
+		CommentRes res = commentService.create(roomId, actor.getId(), req);
+		return ResponseData.success("M-201", "created", res);
 	}
 
 	@Operation(summary = "댓글 목록 조회", description = "운동방 댓글을 페이지 단위로 조회합니다.")
 	@GetMapping
 	public ResponseData<Page<CommentRes>> list(@PathVariable Long roomId,
-		@AuthenticationPrincipal Object authUser,
 		@RequestParam(defaultValue = "0") int page,
 		@RequestParam(defaultValue = "20") int size) {
-		Long userId = extractUserId(authUser);
-		Page<CommentRes> resPage = commentService.list(roomId, userId, page, size);
-		return ResponseData.success("200-0", "success", resPage);
+		User actor = requestContext.getActor();
+		Page<CommentRes> resPage = commentService.list(roomId, actor.getId(), page, size);
+		return ResponseData.success("M-200", "success", resPage);
 	}
 
 	@Operation(summary = "댓글 수정", description = "작성자가 본인의 댓글을 수정합니다.")
 	@PatchMapping("/{commentId}")
 	public ResponseData<CommentRes> edit(@PathVariable Long roomId,
 		@PathVariable Long commentId,
-		@AuthenticationPrincipal Object authUser,
 		@Valid @RequestBody CommentEditReq req) {
-		Long userId = extractUserId(authUser);
-		CommentRes res = commentService.edit(roomId, commentId, userId, req);
-		return ResponseData.success("200-0", "updated", res);
+		User actor = requestContext.getActor();
+		CommentRes res = commentService.edit(roomId, commentId, actor.getId(), req);
+		return ResponseData.success("M-200", "updated", res);
 	}
 
 	@Operation(summary = "댓글 삭제", description = "작성자가 본인의 댓글을 삭제합니다.")
 	@DeleteMapping("/{commentId}")
-	public ResponseData<Void> delete(@PathVariable Long roomId,
-		@PathVariable Long commentId,
-		@AuthenticationPrincipal Object authUser) {
-		Long userId = extractUserId(authUser);
-		commentService.delete(roomId, commentId, userId);
-		return ResponseData.success("204-0", "deleted", null);
+	public ResponseData<CommentRes> delete(@PathVariable Long roomId,
+		@PathVariable Long commentId) {
+		User actor = requestContext.getActor();
+		CommentRes deletedComment = commentService.delete(roomId, commentId, actor.getId());
+		return ResponseData.success("M-200", "deleted", deletedComment);
 	}
 
 	// ------------------- 임시 유저ID 추출 (로그인 붙이면 교체 예정) -------------------

--- a/motionit/src/main/java/com/back/motionit/domain/challenge/comment/service/CommentService.java
+++ b/motionit/src/main/java/com/back/motionit/domain/challenge/comment/service/CommentService.java
@@ -66,7 +66,6 @@ public class CommentService {
 		Comment c = commentRepository.findByIdAndChallengeRoom_Id(commentId, roomId)
 			.orElseThrow(() -> new BusinessException(CommentErrorCode.COMMENT_NOT_FOUND));
 
-
 		if (!c.getUser().getId().equals(userId)) {
 			throw new BusinessException(CommentErrorCode.WRONG_ACCESS);
 		}
@@ -76,7 +75,7 @@ public class CommentService {
 	}
 
 	@Transactional
-	public void delete(Long roomId, Long commentId, Long userId) {
+	public CommentRes delete(Long roomId, Long commentId, Long userId) {
 
 		Comment c = commentRepository.findByIdAndChallengeRoom_Id(commentId, roomId)
 			.orElseThrow(() -> new BusinessException(CommentErrorCode.COMMENT_NOT_FOUND));
@@ -85,6 +84,7 @@ public class CommentService {
 		}
 
 		c.softDelete();
+		return CommentRes.from(c);
 	}
 
 }


### PR DESCRIPTION
<!--
  템플릿은 아직 PR 작성이 익숙하지 않으신 분들을 위해서 제공하는 가이드입니다!
  리뷰어 또는 이 PR을 보게 될 다른 사람들이 이 PR을 보는데 참고할 수 있는 내용이 있다면 포함해서 작성해주시면 됩니다.
-->

## 관련 이슈

- Close #107 

## PR / 과제 설명 

- 댓글 프론트 구현입니다

- 백엔드
   - 댓글 인증인가 getActor()사용 반영
   - 댓글 응답 메세지 M-000 으로 통일
   - delete의 경우 204응답일 경우 프론트에서 json파싱 문제 있어 200으로 임의 변경

- 프론트
   - 댓글 CRUD로 화면에 데이터 뿌려주기
   - 댓글 엔터로 입력, 수정시 해당 댓글이 있던 필드에서 입력

논의해야할 점: 댓글 페이징이 안됩니다.

<img width="1295" height="1280" alt="image" src="https://github.com/user-attachments/assets/ae1b0167-4e0a-49b1-ba30-a55bc5cfc3e9" />