### PR TITLE
feat: 운동방 삭제 API 추가

### DIFF
--- a/motionit/src/main/java/com/back/motionit/domain/challenge/participant/service/ChallengeParticipantService.java
+++ b/motionit/src/main/java/com/back/motionit/domain/challenge/participant/service/ChallengeParticipantService.java
@@ -74,4 +74,23 @@ public class ChallengeParticipantService {
 	public boolean isActiveParticipant(Long userId, Long roomId) {
 		return challengeParticipantRepository.existsActiveParticipant(userId, roomId);
 	}
+
+	public boolean checkParticipantIsRoomHost(Long userId, Long roomId) {
+
+		User user = userRepository.findById(userId)
+			.orElseThrow(() -> new BusinessException(ChallengeParticipantErrorCode.NOT_FOUND_USER));
+
+		ChallengeRoom challengeRoom = challengeRoomRepository.findById(roomId)
+			.orElseThrow(() -> new BusinessException(ChallengeParticipantErrorCode.CANNOT_FIND_CHALLENGE_ROOM));
+
+		ChallengeParticipant participant = challengeParticipantRepository
+			.findByUserAndChallengeRoom(user, challengeRoom)
+			.orElseThrow(() -> new BusinessException(ChallengeParticipantErrorCode.NO_PARTICIPANT_IN_ROOM));
+
+		if (participant.getRole().equals(ChallengeParticipantRole.HOST)) {
+			return true;
+		}
+
+		return false;
+	}
 }

--- a/motionit/src/main/java/com/back/motionit/domain/challenge/room/api/ChallengeRoomApi.java
+++ b/motionit/src/main/java/com/back/motionit/domain/challenge/room/api/ChallengeRoomApi.java
@@ -2,6 +2,7 @@ package com.back.motionit.domain.challenge.room.api;
 
 import java.util.List;
 
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -49,11 +50,21 @@ public interface ChallengeRoomApi {
 	);
 
 	@GetMapping("/{roomId}")
-	@Operation(summary = "Get Challenge Rooms", description = "특정 운동방 상세 정보를 조회합니다.")
+	@Operation(summary = "Get Challenge Room", description = "특정 운동방 상세 정보를 조회합니다.")
 	@ApiResponses({
 		@ApiResponse(responseCode = ChallengeRoomHttp.GET_ROOM_SUCCESS_CODE,
 			description = ChallengeRoomHttp.GET_ROOM_SUCCESS_MESSAGE,
 			content = @Content(schema = @Schema(implementation = GetRoomResponse.class)))
 	})
 	ResponseData<GetRoomResponse> getRoom(@PathVariable("roomId") @NotNull Long roomId);
+
+	@DeleteMapping("/{roomId}")
+	@Operation(summary = "Delete Challenge Room", description = "특정 운동방을 삭제합니다.")
+	@ApiResponses({
+		@ApiResponse(
+			responseCode = ChallengeRoomHttp.DELETE_ROOM_SUCCESS_CODE,
+			description = ChallengeRoomHttp.DELETE_ROOM_SUCCESS_MESSAGE
+		)
+	})
+	ResponseData<Void> deleteRoom(@PathVariable("roomId") @NotNull Long roomId);
 }

--- a/motionit/src/main/java/com/back/motionit/domain/challenge/room/api/response/ChallengeRoomHttp.java
+++ b/motionit/src/main/java/com/back/motionit/domain/challenge/room/api/response/ChallengeRoomHttp.java
@@ -9,4 +9,7 @@ public class ChallengeRoomHttp {
 
 	public static final String GET_ROOM_SUCCESS_CODE = "R-200";
 	public static final String GET_ROOM_SUCCESS_MESSAGE = "Success to get challenge room";
+
+	public static final String DELETE_ROOM_SUCCESS_CODE = "R-200";
+	public static final String DELETE_ROOM_SUCCESS_MESSAGE = "Success to delete challenge room";
 }

--- a/motionit/src/main/java/com/back/motionit/domain/challenge/room/controller/ChallengeRoomController.java
+++ b/motionit/src/main/java/com/back/motionit/domain/challenge/room/controller/ChallengeRoomController.java
@@ -59,4 +59,12 @@ public class ChallengeRoomController implements ChallengeRoomApi {
 		return ResponseData.success(ChallengeRoomHttp.GET_ROOM_SUCCESS_CODE,
 			ChallengeRoomHttp.GET_ROOM_SUCCESS_MESSAGE, response);
 	}
+
+	@Override
+	public ResponseData<Void> deleteRoom(@PathVariable("roomId") @NotNull Long roomId) {
+		User user = httpRequest.getActor();
+		challengeRoomService.deleteRoom(roomId, user);
+		return ResponseData.success(ChallengeRoomHttp.DELETE_ROOM_SUCCESS_CODE,
+			ChallengeRoomHttp.DELETE_ROOM_SUCCESS_MESSAGE, null);
+	}
 }

--- a/motionit/src/main/java/com/back/motionit/domain/challenge/room/dto/ChallengeRoomDeleted.java
+++ b/motionit/src/main/java/com/back/motionit/domain/challenge/room/dto/ChallengeRoomDeleted.java
@@ -1,0 +1,8 @@
+package com.back.motionit.domain.challenge.room.dto;
+
+import com.back.motionit.global.enums.EventEnums;
+
+public record ChallengeRoomDeleted(
+	EventEnums event
+) {
+}

--- a/motionit/src/main/java/com/back/motionit/domain/challenge/room/entity/ChallengeRoom.java
+++ b/motionit/src/main/java/com/back/motionit/domain/challenge/room/entity/ChallengeRoom.java
@@ -6,6 +6,8 @@ import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.hibernate.annotations.SQLRestriction;
+
 import com.back.motionit.domain.challenge.participant.entity.ChallengeParticipant;
 import com.back.motionit.domain.challenge.video.entity.ChallengeVideo;
 import com.back.motionit.domain.challenge.video.entity.OpenStatus;
@@ -15,6 +17,8 @@ import com.back.motionit.global.jpa.entity.BaseEntity;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
@@ -30,6 +34,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Getter
 @Table(name = "challenge_rooms")
+@SQLRestriction("deleted_at IS NULL")
 public class ChallengeRoom extends BaseEntity {
 
 	@ManyToOne(fetch = FetchType.LAZY)
@@ -41,6 +46,8 @@ public class ChallengeRoom extends BaseEntity {
 	@Column(name = "description", length = 2000)
 	private String description;
 	private Integer capacity;
+
+	@Enumerated(EnumType.STRING)
 	private OpenStatus openStatus;
 
 	@Column(name = "challenge_start_date")
@@ -51,6 +58,9 @@ public class ChallengeRoom extends BaseEntity {
 
 	@Column(name = "roome_image")
 	private String roomImage; // 챌린지룸 이미지 URL
+
+	@Column(name = "deleted_at")
+	private LocalDateTime deletedAt;
 
 	@OneToMany(
 		mappedBy = "challengeRoom",

--- a/motionit/src/main/java/com/back/motionit/domain/challenge/room/event/DeleteRoomBroadcaster.java
+++ b/motionit/src/main/java/com/back/motionit/domain/challenge/room/event/DeleteRoomBroadcaster.java
@@ -1,0 +1,24 @@
+package com.back.motionit.domain.challenge.room.event;
+
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import com.back.motionit.domain.challenge.room.dto.ChallengeRoomDeleted;
+import com.back.motionit.global.event.Broadcaster;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class DeleteRoomBroadcaster implements Broadcaster<ChallengeRoomDeleted> {
+
+	private final SimpMessagingTemplate messagingTemplate;
+
+	@Override
+	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+	public void onCreated(ChallengeRoomDeleted event) {
+		messagingTemplate.convertAndSend("/topic/challenge/rooms", event);
+	}
+}

--- a/motionit/src/main/java/com/back/motionit/domain/challenge/room/repository/ChallengeRoomRepository.java
+++ b/motionit/src/main/java/com/back/motionit/domain/challenge/room/repository/ChallengeRoomRepository.java
@@ -1,5 +1,6 @@
 package com.back.motionit.domain.challenge.room.repository;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 import org.springframework.data.domain.Page;
@@ -7,6 +8,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -26,4 +28,16 @@ public interface ChallengeRoomRepository extends JpaRepository<ChallengeRoom, Lo
 
 	@EntityGraph(attributePaths = {"challengeVideoList"})
 	Optional<ChallengeRoom> findWithVideosById(Long id);
+
+	@Modifying(clearAutomatically = true, flushAutomatically = true)
+	@Query("""
+		    UPDATE ChallengeRoom r
+		       SET r.deletedAt = CURRENT_TIMESTAMP,
+		           r.openStatus = 'CLOSED'
+		     WHERE r.id = :id
+		""")
+	int softDeleteById(@Param("id") Long id);
+
+	@Query(value = "SELECT deleted_at FROM challenge_rooms WHERE id = :id", nativeQuery = true)
+	LocalDateTime findDeletedAtRaw(@Param("id") Long id);
 }

--- a/motionit/src/main/java/com/back/motionit/global/error/code/ChallengeRoomErrorCode.java
+++ b/motionit/src/main/java/com/back/motionit/global/error/code/ChallengeRoomErrorCode.java
@@ -9,7 +9,9 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum ChallengeRoomErrorCode implements ErrorCode {
 	NOT_FOUND_USER(HttpStatus.NOT_FOUND, "R-001", "유저를 찾을 수 없습니다."),
-	NOT_FOUND_ROOM(HttpStatus.NOT_FOUND, "R-002", "운동방을 찾을 수 없습니다.");
+	NOT_FOUND_ROOM(HttpStatus.NOT_FOUND, "R-002", "운동방을 찾을 수 없습니다."),
+	INVALID_AUTH_USER(HttpStatus.BAD_REQUEST, "R-003", "권한이 없는 사용자입니다."),
+	FAILED_DELETE_ROOM(HttpStatus.BAD_REQUEST, "R-004", "방 삭제에 실패했습니다.");
 
 	private final HttpStatus status;
 	private final String code;

--- a/motionit/src/main/java/com/back/motionit/global/init/DataInitializer.java
+++ b/motionit/src/main/java/com/back/motionit/global/init/DataInitializer.java
@@ -82,6 +82,7 @@ public class DataInitializer {
 				LocalDateTime.now().plusDays(1),  // 내일부터 시작
 				LocalDateTime.now().plusDays(15),
 				"https://picsum.photos/600/300?challenge",
+				null,
 				new ArrayList<>(),
 				new ArrayList<>()
 			);

--- a/motionit/src/test/java/com/back/motionit/domain/challenge/comment/controller/CommentControllerTest.java
+++ b/motionit/src/test/java/com/back/motionit/domain/challenge/comment/controller/CommentControllerTest.java
@@ -94,6 +94,7 @@ class CommentControllerIntegrationTest {
 			LocalDateTime.now().minusDays(1),
 			LocalDateTime.now().plusDays(30),
 			"/img.png",
+			null,
 			new ArrayList<>(),
 			new ArrayList<>()
 		);

--- a/motionit/src/test/java/com/back/motionit/domain/challenge/participant/service/ChallengeParticipantServiceConcurrencyTest.java
+++ b/motionit/src/test/java/com/back/motionit/domain/challenge/participant/service/ChallengeParticipantServiceConcurrencyTest.java
@@ -56,6 +56,7 @@ class ChallengeParticipantServiceConcurrencyTest {
 			LocalDateTime.now(),
 			LocalDateTime.now().plusDays(7),
 			"https://example.com/test-room.png",
+			null,
 			new ArrayList<>(),
 			new ArrayList<>()
 		);

--- a/motionit/src/test/java/com/back/motionit/factory/ChallengeRoomFactory.java
+++ b/motionit/src/test/java/com/back/motionit/factory/ChallengeRoomFactory.java
@@ -38,6 +38,7 @@ public final class ChallengeRoomFactory extends BaseFactory {
 			start,
 			end,
 			faker.internet().url(),
+			null,
 			new ArrayList<>(),
 			new ArrayList<>()
 		);

--- a/motionit/src/test/java/com/back/motionit/helper/ChallengeParticipantHelper.java
+++ b/motionit/src/test/java/com/back/motionit/helper/ChallengeParticipantHelper.java
@@ -1,0 +1,28 @@
+package com.back.motionit.helper;
+
+import org.springframework.stereotype.Component;
+
+import com.back.motionit.domain.challenge.participant.entity.ChallengeParticipant;
+import com.back.motionit.domain.challenge.participant.repository.ChallengeParticipantRepository;
+import com.back.motionit.domain.challenge.room.entity.ChallengeRoom;
+import com.back.motionit.domain.user.entity.User;
+import com.back.motionit.factory.ChallengeParticipantFactory;
+
+@Component
+public class ChallengeParticipantHelper {
+	private ChallengeParticipantRepository participantRepository;
+
+	public ChallengeParticipantHelper(
+		ChallengeParticipantRepository participantRepository
+	) {
+		this.participantRepository = participantRepository;
+	}
+
+	public ChallengeParticipant createHostParticipant(User user, ChallengeRoom room) {
+		return participantRepository.save(ChallengeParticipantFactory.fakeHost(user, room));
+	}
+
+	public ChallengeParticipant createNormalParticipant(User user, ChallengeRoom room) {
+		return participantRepository.save(ChallengeParticipantFactory.fakeParticipant(user, room));
+	}
+}


### PR DESCRIPTION
## 관련 이슈

- Close #102 

## PR / 과제 설명 

- `DELETE /api/v1/challenge/rooms/{roomId}` API 추가
   L `deleteRoom()` 서비스 로직 추가
```
1. 삭제 요청하는 사용자가 운동방의 방장인지 확인 (방장만 삭제 가능하도록 설정)
2. 운동방을 Soft Delete (deletedAt필드를 추가하여, 삭제 성공 시 deletedAt을 삭제 시점 날짜로 저장)
```
**API 결과 예시**
<img width="919" height="584" alt="Screenshot 2025-10-23 at 11 47 30 AM" src="https://github.com/user-attachments/assets/2712850f-9aa3-4712-a1b4-6a7fb2786926" />
<img width="787" height="538" alt="Screenshot 2025-10-23 at 11 47 47 AM" src="https://github.com/user-attachments/assets/2ccac009-2e5e-40e6-84f5-8bd18fa0248c" />

