### PR TITLE
카카오 Unique Key 제약조건 버그 수정

### DIFF
--- a/motionit/src/main/java/com/back/motionit/security/oauth/CustomOAuth2UserService.java
+++ b/motionit/src/main/java/com/back/motionit/security/oauth/CustomOAuth2UserService.java
@@ -36,11 +36,12 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
 		Map<String, Object> attributes = oAuth2User.getAttributes();
 		Map<String, Object> attributesProperties = (Map<String, Object>)attributes.get("properties");
+		Map<String, Object> kakaoAccount = (Map<String, Object>)attributes.get("kakao_account");
 
 		String nickname = (String)attributesProperties.get("nickname");
 		String userProfile = (String)attributesProperties.get("profile_image");
 		String password = "";
-		String email = "";
+		String email = null;
 		LoginType loginType = LoginType.KAKAO;
 
 		User user = socialAuthService.modifyOrJoin(kakaoId, email, nickname, password, loginType, userProfile);


### PR DESCRIPTION
<!--
  템플릿은 아직 PR 작성이 익숙하지 않으신 분들을 위해서 제공하는 가이드입니다!
  리뷰어 또는 이 PR을 보게 될 다른 사람들이 이 PR을 보는데 참고할 수 있는 내용이 있다면 포함해서 작성해주시면 됩니다.
-->

## 관련 이슈

- Close #133 

## PR / 과제 설명 

- MySQL의 UNIQUE 제약 조건은 null 값을 중복으로 취급하지 않음
    (KAKAO, null) 조합은 여러 개 존재 가능
    (KAKAO, "") 조합은 오직 1개만 존재 가능
