### PR TITLE
RequestContext 의존성 제거

### DIFF
--- a/motionit/src/main/java/com/back/motionit/security/handler/CustomOAuth2LoginSuccessHandler.java
+++ b/motionit/src/main/java/com/back/motionit/security/handler/CustomOAuth2LoginSuccessHandler.java
@@ -9,8 +9,8 @@ import org.springframework.security.web.authentication.AuthenticationSuccessHand
 import org.springframework.stereotype.Component;
 
 import com.back.motionit.domain.auth.social.service.SocialAuthService;
-import com.back.motionit.domain.user.entity.User;
 import com.back.motionit.global.request.RequestContext;
+import com.back.motionit.security.SecurityUser;
 import com.back.motionit.security.jwt.JwtTokenDto;
 
 import jakarta.servlet.http.HttpServletRequest;
@@ -28,8 +28,10 @@ public class CustomOAuth2LoginSuccessHandler implements AuthenticationSuccessHan
 	public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
 		Authentication authentication) throws IOException {
 
-		User user = requestContext.getActor();
-		JwtTokenDto tokens = socialAuthService.generateTokensById(user.getId());
+		SecurityUser securityUser = (SecurityUser) authentication.getPrincipal();
+		Long userId = securityUser.getId();
+
+		JwtTokenDto tokens = socialAuthService.generateTokensById(userId);
 
 		requestContext.setCookie("accessToken", tokens.getAccessToken());
 		requestContext.setCookie("refreshToken", tokens.getRefreshToken());


### PR DESCRIPTION
<!--
  템플릿은 아직 PR 작성이 익숙하지 않으신 분들을 위해서 제공하는 가이드입니다!
  리뷰어 또는 이 PR을 보게 될 다른 사람들이 이 PR을 보는데 참고할 수 있는 내용이 있다면 포함해서 작성해주시면 됩니다.
-->

## 관련 이슈

- Close #133 

## PR / 과제 설명 

- requestContext.getActor()는 일반적인 HTTP 요청의 인증된 유저를 가져옴
- 변경후 OAuth2 로그인 프로세스가 생성한 Authentication 객체에서 직접 유저 정보를 가져옴

