### PR TITLE
refactor: 운동방 생성시 비디오 저장

### DIFF
--- a/motionit/src/main/java/com/back/motionit/domain/challenge/comment/controller/CommentController.java
+++ b/motionit/src/main/java/com/back/motionit/domain/challenge/comment/controller/CommentController.java
@@ -36,8 +36,10 @@ public class CommentController {
 
 	@Operation(summary = "댓글 생성", description = "운동방에 댓글을 작성합니다.")
 	@PostMapping
-	public ResponseData<CommentRes> create(@PathVariable Long roomId,
-		@Valid @RequestBody CommentCreateReq req) {
+	public ResponseData<CommentRes> create(
+		@PathVariable("roomId") Long roomId,
+		@Valid @RequestBody CommentCreateReq req
+	) {
 		User actor = requestContext.getActor();
 		CommentRes res = commentService.create(roomId, actor.getId(), req);
 		return ResponseData.success("M-201", "created", res);
@@ -45,9 +47,11 @@ public class CommentController {
 
 	@Operation(summary = "댓글 목록 조회", description = "운동방 댓글을 페이지 단위로 조회합니다.")
 	@GetMapping
-	public ResponseData<Page<CommentRes>> list(@PathVariable Long roomId,
-		@RequestParam(defaultValue = "0") int page,
-		@RequestParam(defaultValue = "20") int size) {
+	public ResponseData<Page<CommentRes>> list(
+		@PathVariable("roomId") Long roomId,
+		@RequestParam(name = "page", defaultValue = "0") int page,
+		@RequestParam(name = "size", defaultValue = "20") int size
+	) {
 		User actor = requestContext.getActor();
 		Page<CommentRes> resPage = commentService.list(roomId, actor.getId(), page, size);
 		return ResponseData.success("M-200", "success", resPage);
@@ -55,9 +59,11 @@ public class CommentController {
 
 	@Operation(summary = "댓글 수정", description = "작성자가 본인의 댓글을 수정합니다.")
 	@PatchMapping("/{commentId}")
-	public ResponseData<CommentRes> edit(@PathVariable Long roomId,
-		@PathVariable Long commentId,
-		@Valid @RequestBody CommentEditReq req) {
+	public ResponseData<CommentRes> edit(
+		@PathVariable("roomId") Long roomId,
+		@PathVariable("commentId") Long commentId,
+		@Valid @RequestBody CommentEditReq req
+	) {
 		User actor = requestContext.getActor();
 		CommentRes res = commentService.edit(roomId, commentId, actor.getId(), req);
 		return ResponseData.success("M-200", "updated", res);
@@ -65,8 +71,10 @@ public class CommentController {
 
 	@Operation(summary = "댓글 삭제", description = "작성자가 본인의 댓글을 삭제합니다.")
 	@DeleteMapping("/{commentId}")
-	public ResponseData<CommentRes> delete(@PathVariable Long roomId,
-		@PathVariable Long commentId) {
+	public ResponseData<CommentRes> delete(
+		@PathVariable("roomId") Long roomId,
+		@PathVariable("commentId") Long commentId
+	) {
 		User actor = requestContext.getActor();
 		CommentRes deletedComment = commentService.delete(roomId, commentId, actor.getId());
 		return ResponseData.success("M-200", "deleted", deletedComment);

--- a/motionit/src/main/java/com/back/motionit/domain/challenge/like/api/CommentLikeApi.java
+++ b/motionit/src/main/java/com/back/motionit/domain/challenge/like/api/CommentLikeApi.java
@@ -18,6 +18,6 @@ public interface CommentLikeApi {
 	@PostMapping("/{commentId}/likes")
 	@ResponseStatus(HttpStatus.OK)
 	ResponseData<CommentRes> toggleCommentLikeByCommentId(
-		@PathVariable Long commentId);
+		@PathVariable("commentId") Long commentId);
 }
 

--- a/motionit/src/main/java/com/back/motionit/domain/challenge/like/controller/CommentLikeController.java
+++ b/motionit/src/main/java/com/back/motionit/domain/challenge/like/controller/CommentLikeController.java
@@ -22,7 +22,7 @@ public class CommentLikeController implements CommentLikeApi {
 	private final RequestContext requestContext;
 
 	@Override
-	public ResponseData<CommentRes> toggleCommentLikeByCommentId(@PathVariable Long commentId) {
+	public ResponseData<CommentRes> toggleCommentLikeByCommentId(@PathVariable("commentId") Long commentId) {
 		User actor = requestContext.getActor();
 
 		CommentRes updatedComment = commentLikeService.toggleCommentLikeByCommentId(commentId, actor.getId());

--- a/motionit/src/main/java/com/back/motionit/domain/challenge/mission/api/ChallengeMissionStatusApi.java
+++ b/motionit/src/main/java/com/back/motionit/domain/challenge/mission/api/ChallengeMissionStatusApi.java
@@ -21,7 +21,7 @@ public interface ChallengeMissionStatusApi {
 	@Operation(summary = "AI 응원메세지 받아오기",
 		description = "AI 응원메세지 받아오기"
 	)
-	ResponseData<String> generateAiSummary(@PathVariable Long roomId);
+	ResponseData<String> generateAiSummary(@PathVariable("roomId") Long roomId);
 
 	@PostMapping("/api/v1/challenge/rooms/{roomId}/missions/complete")
 	@Operation(summary = "미션 완료 처리",
@@ -34,7 +34,7 @@ public interface ChallengeMissionStatusApi {
 			@ApiResponse(responseCode = "400", description = "존재하지 않는 유저 또는 방 / 이미 완료된 미션")
 		})
 	ResponseData<ChallengeMissionStatusResponse> completeMission(
-		@PathVariable Long roomId
+		@PathVariable("roomId") Long roomId
 	);
 
 	@GetMapping("/api/v1/challenge/rooms/{roomId}/missions/today")
@@ -51,7 +51,7 @@ public interface ChallengeMissionStatusApi {
 			@ApiResponse(responseCode = "400", description = "존재하지 않는 운동방")
 		})
 	ResponseData<List<ChallengeMissionStatusResponse>> getTodayMissionByRoom(
-		@PathVariable Long roomId
+		@PathVariable("roomId") Long roomId
 	);
 
 	@GetMapping("/api/v1/challenge/rooms/{roomId}/missions//personal/today")
@@ -65,7 +65,7 @@ public interface ChallengeMissionStatusApi {
 			@ApiResponse(responseCode = "400", description = "존재하지 않는 유저 또는 방")
 		})
 	ResponseData<ChallengeMissionStatusResponse> getTodayMissionStatus(
-		@PathVariable Long roomId
+		@PathVariable("roomId") Long roomId
 	);
 
 	@GetMapping("/api/v1/challenge/rooms/{roomId}/missions/personal/history")
@@ -79,7 +79,7 @@ public interface ChallengeMissionStatusApi {
 			@ApiResponse(responseCode = "400", description = "존재하지 않는 유저 또는 방")
 		})
 	ResponseData<List<ChallengeMissionStatusResponse>> getMissionHistory(
-		@PathVariable Long roomId
+		@PathVariable("roomId") Long roomId
 	);
 
 }

--- a/motionit/src/main/java/com/back/motionit/domain/challenge/mission/controller/ChallengeMissionStatusController.java
+++ b/motionit/src/main/java/com/back/motionit/domain/challenge/mission/controller/ChallengeMissionStatusController.java
@@ -44,7 +44,7 @@ public class ChallengeMissionStatusController implements ChallengeMissionStatusA
 
 	@PostMapping("/complete")
 	public ResponseData<ChallengeMissionStatusResponse> completeMission(
-		@PathVariable Long roomId
+		@PathVariable("roomId") Long roomId
 	) {
 		User actor = requestContext.getActor();
 		// 방 참여자가 아닐경우 API 접근 차단
@@ -62,7 +62,7 @@ public class ChallengeMissionStatusController implements ChallengeMissionStatusA
 
 	@GetMapping("/today")
 	public ResponseData<List<ChallengeMissionStatusResponse>> getTodayMissionByRoom(
-		@PathVariable Long roomId
+		@PathVariable("roomId") Long roomId
 	) {
 		User actor = requestContext.getActor();
 		// 방 참여자가 아닐경우 API 접근 차단
@@ -82,7 +82,7 @@ public class ChallengeMissionStatusController implements ChallengeMissionStatusA
 
 	@GetMapping("/personal/today")
 	public ResponseData<ChallengeMissionStatusResponse> getTodayMissionStatus(
-		@PathVariable Long roomId
+		@PathVariable("roomId") Long roomId
 	) {
 		User actor = requestContext.getActor();
 		// 방 참여자가 아닐경우 API 접근 차단
@@ -95,7 +95,7 @@ public class ChallengeMissionStatusController implements ChallengeMissionStatusA
 
 	@GetMapping("/personal/history")
 	public ResponseData<List<ChallengeMissionStatusResponse>> getMissionHistory(
-		@PathVariable Long roomId
+		@PathVariable("roomId") Long roomId
 	) {
 		User actor = requestContext.getActor();
 		// 방 참여자가 아닐경우 API 접근 차단

--- a/motionit/src/main/java/com/back/motionit/domain/challenge/participant/api/ChallengeParticipantApi.java
+++ b/motionit/src/main/java/com/back/motionit/domain/challenge/participant/api/ChallengeParticipantApi.java
@@ -29,7 +29,7 @@ public interface ChallengeParticipantApi {
 			@ApiResponse(responseCode = "404", description = "존재하지 않는 방 또는 유저")
 		})
 	ResponseData<Void> joinChallengeRoom(
-		@PathVariable @NotNull Long roomId
+		@PathVariable("roomId") @NotNull Long roomId
 	);
 
 	@PostMapping("/{roomId}/leave")
@@ -44,12 +44,12 @@ public interface ChallengeParticipantApi {
 			@ApiResponse(responseCode = "404", description = "존재하지 않는 방 또는 유저")
 		})
 	ResponseData<Void> leaveChallengeRoom(
-		@PathVariable @NotNull Long roomId
+		@PathVariable("roomId") @NotNull Long roomId
 	);
 
 	@GetMapping("/{roomId}/status")
 	@Operation(summary = "사용자의 운동방 가입여부 조회",
 		description = "현 로그인상태인 사용자가 해당 운동방 가입상태인지 조회"
 	)
-	ResponseData<ChallengeParticipantResponse> getParticipationStatus(@PathVariable Long roomId);
+	ResponseData<ChallengeParticipantResponse> getParticipationStatus(@PathVariable("roomId") Long roomId);
 }

--- a/motionit/src/main/java/com/back/motionit/domain/challenge/participant/controller/ChallengeParticipantController.java
+++ b/motionit/src/main/java/com/back/motionit/domain/challenge/participant/controller/ChallengeParticipantController.java
@@ -28,7 +28,7 @@ public class ChallengeParticipantController implements ChallengeParticipantApi {
 	private final ChallengeAuthValidator challengeAuthValidator;
 
 	@PostMapping("/{roomId}/join")
-	public ResponseData<Void> joinChallengeRoom(@PathVariable @NotNull Long roomId) {
+	public ResponseData<Void> joinChallengeRoom(@PathVariable("roomId") @NotNull Long roomId) {
 		User actor = requestContext.getActor();
 
 		challengeParticipantService.joinChallengeRoom(actor.getId(), roomId);
@@ -36,7 +36,7 @@ public class ChallengeParticipantController implements ChallengeParticipantApi {
 	}
 
 	@PostMapping("/{roomId}/leave")
-	public ResponseData<Void> leaveChallengeRoom(@PathVariable @NotNull Long roomId) {
+	public ResponseData<Void> leaveChallengeRoom(@PathVariable("roomId") @NotNull Long roomId) {
 		User actor = requestContext.getActor();
 		challengeAuthValidator.validateActiveParticipant(actor.getId(), roomId);
 
@@ -45,7 +45,7 @@ public class ChallengeParticipantController implements ChallengeParticipantApi {
 	}
 
 	@GetMapping("/{roomId}/status")
-	public ResponseData<ChallengeParticipantResponse> getParticipationStatus(@PathVariable Long roomId) {
+	public ResponseData<ChallengeParticipantResponse> getParticipationStatus(@PathVariable("roomId") Long roomId) {
 		User actor = requestContext.getActor();
 		boolean joined = challengeParticipantService.isActiveParticipant(actor.getId(), roomId);
 

--- a/motionit/src/main/java/com/back/motionit/domain/challenge/video/api/ChallengeVideoApi.java
+++ b/motionit/src/main/java/com/back/motionit/domain/challenge/video/api/ChallengeVideoApi.java
@@ -32,7 +32,7 @@ public interface ChallengeVideoApi {
 			@ApiResponse(responseCode = "500", description = "유튜브 API 호출 실패")
 		})
 	ResponseData<ChallengeVideoResponse> uploadVideo(
-		@PathVariable Long roomId,
+		@PathVariable("roomId") Long roomId,
 		@RequestBody @Valid ChallengeVideoUploadRequest request
 	);
 
@@ -46,7 +46,7 @@ public interface ChallengeVideoApi {
 			)
 		})
 	ResponseData<List<ChallengeVideoResponse>> getTodayMissionVideos(
-		@PathVariable Long roomId
+		@PathVariable("roomId") Long roomId
 	);
 
 	@DeleteMapping("/api/v1/challenge/rooms/{roomId}/videos/{videoId}")
@@ -61,7 +61,7 @@ public interface ChallengeVideoApi {
 			@ApiResponse(responseCode = "404", description = "존재하지 않는 영상")
 		})
 	ResponseData<Void> deleteVideoByUser(
-		@PathVariable Long roomId,
-		@PathVariable Long videoId
+		@PathVariable("roomId") Long roomId,
+		@PathVariable("videoId") Long videoId
 	);
 }

--- a/motionit/src/main/java/com/back/motionit/domain/challenge/video/controller/ChallengeVideoController.java
+++ b/motionit/src/main/java/com/back/motionit/domain/challenge/video/controller/ChallengeVideoController.java
@@ -33,7 +33,7 @@ public class ChallengeVideoController implements ChallengeVideoApi {
 
 	@PostMapping("/rooms/{roomId}/videos")
 	public ResponseData<ChallengeVideoResponse> uploadVideo(
-		@PathVariable Long roomId,
+		@PathVariable("roomId") Long roomId,
 		@RequestBody @Valid ChallengeVideoUploadRequest request
 	) {
 		User actor = requestContext.getActor();
@@ -45,7 +45,7 @@ public class ChallengeVideoController implements ChallengeVideoApi {
 	}
 
 	@GetMapping("/rooms/{roomId}/videos/today")
-	public ResponseData<List<ChallengeVideoResponse>> getTodayMissionVideos(@PathVariable Long roomId) {
+	public ResponseData<List<ChallengeVideoResponse>> getTodayMissionVideos(@PathVariable("roomId") Long roomId) {
 		User actor = requestContext.getActor();
 
 		List<ChallengeVideoResponse> videos = challengeVideoService.getTodayMissionVideos(actor.getId(), roomId)
@@ -58,8 +58,8 @@ public class ChallengeVideoController implements ChallengeVideoApi {
 
 	@DeleteMapping("/rooms/{roomId}/videos/{videoId}")
 	public ResponseData<Void> deleteVideoByUser(
-		@PathVariable Long roomId,
-		@PathVariable Long videoId
+		@PathVariable("roomId") Long roomId,
+		@PathVariable("videoId") Long videoId
 	) {
 		User actor = requestContext.getActor();
 

--- a/motionit/src/test/java/com/back/motionit/domain/challenge/room/builder/CreateRoomRequestBuilder.java
+++ b/motionit/src/test/java/com/back/motionit/domain/challenge/room/builder/CreateRoomRequestBuilder.java
@@ -21,12 +21,13 @@ public class CreateRoomRequestBuilder {
 
 	private String contentType;
 
-	public CreateRoomRequestBuilder() {
+	public CreateRoomRequestBuilder(String videoUrl) {
 		this.title = truncate(faker.lorem().characters(8, 30, true), 30);
 		this.description = truncate(faker.lorem().characters(20, 100, true), 100);
 		this.capacity = faker.number().numberBetween(2, 100);
 		this.duration = faker.number().numberBetween(3, 30);
-		this.videoUrl = "https://youtube.com/watch?v=" + faker.regexify("[A-Za-z0-9_-]{11}");
+		this.videoUrl =
+			videoUrl != null ? videoUrl : "https://youtube.com/watch?v=" + faker.regexify("[A-Za-z0-9_-]{11}");
 		this.imageFileName = faker.file().fileName(null, null, "png", null);
 		this.contentType = "image/png";
 	}

--- a/motionit/src/test/java/com/back/motionit/domain/challenge/room/controller/ChallengeRoomControllerTest.java
+++ b/motionit/src/test/java/com/back/motionit/domain/challenge/room/controller/ChallengeRoomControllerTest.java
@@ -80,7 +80,7 @@ public class ChallengeRoomControllerTest {
 
 	@BeforeEach
 	public void setUp() {
-		createRoomRequestBuilder = new CreateRoomRequestBuilder();
+		createRoomRequestBuilder = new CreateRoomRequestBuilder("https://www.youtube.com/watch?v=dQw4w9WgXcQ");
 		user = userHelper.createUser();
 	}
 


### PR DESCRIPTION
## 관련 이슈

- Close #135 

## PR / 과제 설명 

- `POST /api/v1/challenge/rooms` 호출 시, createRoom() 서비스 로직에서 비디오 저장
