### PR TITLE
[FE] 댓글 페이징, 운동 영상 섹션 4개 단위 페이징 추가

### DIFF
--- a/frontend/motionit/src/app/rooms/[roomId]/page.tsx
+++ b/frontend/motionit/src/app/rooms/[roomId]/page.tsx
@@ -5,7 +5,7 @@ import { useParams, useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 import { challengeService } from "@/services";
 import type { ChallengeVideo, ChallengeMissionStatus } from "@/type";
-import { UploadVideoForm, VideoItem, CommentSection } from "@/components";
+import { UploadVideoForm, VideoItem, CommentSection, VideoListSection } from "@/components";
 
 export default function RoomDetailPage() {
   const params = useParams();
@@ -175,22 +175,12 @@ export default function RoomDetailPage() {
           <h2 className="text-lg font-semibold text-gray-900 mb-4 border-b pb-3">
             오늘의 운동 영상
           </h2>
-
+          
+          {/* 운동 영상 */}
           {videos.length === 0 ? (
-            <p className="text-gray-500 text-sm">
-              아직 업로드된 영상이 없습니다.
-            </p>
+            <p className="text-gray-500 text-sm">아직 업로드된 영상이 없습니다.</p>
           ) : (
-            <div className="grid grid-cols-1 sm:grid-cols-2 gap-6">
-              {videos.map((video) => (
-                <VideoItem
-                  key={video.id}
-                  video={video}
-                  roomId={roomId}
-                  onDeleted={fetchVideos}
-                />
-              ))}
-            </div>
+            <VideoListSection videos={videos} roomId={roomId} onRefresh={fetchVideos} />
           )}
 
           {/* 새 영상 업로드 */}

--- a/frontend/motionit/src/components/CommentSection.tsx
+++ b/frontend/motionit/src/components/CommentSection.tsx
@@ -1,11 +1,11 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-// 📁 src/components/CommentSection.tsx
 "use client";
 
 import { useEffect, useState } from "react";
 import { challengeService } from "@/services";
 import type { Comment } from "@/type";
-import { Heart } from "lucide-react"; // 💖 아이콘 (lucide-react 패키지 사용)
+import Pagination from "@/components/common/Pagination";
+import { Heart } from "lucide-react";
 
 interface CommentSectionProps {
   roomId: number;
@@ -43,15 +43,7 @@ export default function CommentSection({ roomId }: CommentSectionProps) {
       fetchComments(currentPage);
     } catch (err) {
       console.error("댓글 작성 실패:", err);
-      // alert는 client.ts에서 이미 처리됨
     }
-  };
-
-  /** Enter 키로 댓글 등록 */
-  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    if ((e.nativeEvent as any).isComposing || e.key !== "Enter" || e.shiftKey) return;
-    e.preventDefault();
-    handleAddComment();
   };
 
   /** 수정 시작 */
@@ -91,7 +83,6 @@ export default function CommentSection({ roomId }: CommentSectionProps) {
 
   /** 좋아요 토글 */
   const handleToggleLike = async (commentId: number) => {
-    // 1️⃣ 현재 상태 즉시 반영 (Optimistic Update)
     setComments((prev) =>
       prev.map((c) =>
         c.id === commentId
@@ -105,11 +96,9 @@ export default function CommentSection({ roomId }: CommentSectionProps) {
     );
 
     try {
-      // 2️⃣ 서버 반영
       const res = await challengeService.toggleCommentLike(commentId);
       const updated = res.data;
 
-      // 3️⃣ 서버 응답 기준으로 최종 동기화 (정확한 값으로)
       setComments((prev) =>
         prev.map((c) =>
           c.id === commentId
@@ -119,18 +108,14 @@ export default function CommentSection({ roomId }: CommentSectionProps) {
       );
     } catch (err: any) {
       console.error("좋아요 토글 실패:", err);
-
-      // 4️⃣ Optimistic Lock 충돌 시 롤백
       if (err?.response?.data?.msg?.includes("LIKE_TOGGLE_FAILED")) {
-        alert("잠시 후 다시 시도해주세요. 다른 사용자의 동작과 충돌했습니다.");
-
-        // 롤백 (UI 되돌리기)
+        alert("잠시 후 다시 시도해주세요.");
         setComments((prev) =>
           prev.map((c) =>
             c.id === commentId
               ? {
                   ...c,
-                  isLiked: !c.isLiked, // 원래대로 복원
+                  isLiked: !c.isLiked,
                   likeCount: c.isLiked ? c.likeCount + 1 : c.likeCount - 1,
                 }
               : c
@@ -152,25 +137,36 @@ export default function CommentSection({ roomId }: CommentSectionProps) {
     <div className="mt-8 border-t pt-6">
       <h3 className="text-base font-semibold text-gray-900 mb-3">댓글</h3>
 
-      {/* 입력 */}
+      {/* 입력창 */}
       <div className="flex space-x-2 mb-4">
-        <input
-          type="text"
+        <textarea
           value={newComment}
-          onChange={(e) => setNewComment(e.target.value)}
-          onKeyDown={handleKeyDown}
-          placeholder="댓글을 입력하세요... (Enter로 등록)"
-          className="flex-1 border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring focus:ring-green-200"
+          onChange={(e) => {
+            setNewComment(e.target.value);
+            e.target.style.height = "auto";
+            e.target.style.height = e.target.scrollHeight + "px";
+          }}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" && !e.shiftKey) {
+              e.preventDefault();
+              handleAddComment();
+            }
+          }}
+          placeholder="댓글을 입력하세요... (Enter로 등록, Shift+Enter 줄바꿈)"
+          className="flex-1 border border-gray-300 rounded-lg px-3 py-2 text-sm 
+          focus:outline-none focus:ring focus:ring-green-200 resize-none 
+          overflow-hidden min-h-[40px] max-h-[200px]"
         />
         <button
           onClick={handleAddComment}
-          className="bg-green-600 text-white px-4 py-2 rounded-lg text-sm hover:bg-green-700 transition"
+          className="bg-green-600 text-white px-4 py-2 rounded-lg text-sm 
+          hover:bg-green-700 transition self-start"
         >
           등록
         </button>
       </div>
 
-      {/* 리스트 */}
+      {/* 댓글 리스트 */}
       {comments.length === 0 ? (
         <p className="text-gray-500 text-sm">아직 댓글이 없습니다.</p>
       ) : (
@@ -185,11 +181,11 @@ export default function CommentSection({ roomId }: CommentSectionProps) {
 
                 {editingCommentId === c.id ? (
                   <div className="mt-1">
-                    <input
-                      type="text"
+                    <textarea
                       value={editingContent}
                       onChange={(e) => setEditingContent(e.target.value)}
-                      className="w-full border border-gray-300 rounded-md px-2 py-1 text-sm focus:outline-none focus:ring focus:ring-blue-200"
+                      className="w-full border border-gray-300 rounded-md px-2 py-1 
+                      text-sm focus:outline-none focus:ring focus:ring-blue-200 resize-none"
                     />
                     <div className="flex space-x-2 mt-2">
                       <button
@@ -208,8 +204,9 @@ export default function CommentSection({ roomId }: CommentSectionProps) {
                   </div>
                 ) : (
                   <>
+                    {/* ✅ 줄바꿈 적용 부분 */}
                     <p
-                      className={`text-sm ${
+                      className={`text-sm whitespace-pre-wrap ${
                         c.deleted ? "text-gray-400 italic" : "text-gray-700"
                       }`}
                     >
@@ -224,7 +221,6 @@ export default function CommentSection({ roomId }: CommentSectionProps) {
 
               {/* 오른쪽 버튼 그룹 */}
               <div className="flex flex-col items-end space-y-1 ml-4">
-                {/* ❤️ 좋아요 버튼 */}
                 {!c.deleted && (
                   <button
                     onClick={() => handleToggleLike(c.id)}
@@ -239,7 +235,6 @@ export default function CommentSection({ roomId }: CommentSectionProps) {
                   </button>
                 )}
 
-                {/* ✏️ 수정 / 삭제 */}
                 {!c.deleted && editingCommentId !== c.id && (
                   <>
                     <button
@@ -261,6 +256,14 @@ export default function CommentSection({ roomId }: CommentSectionProps) {
           ))}
         </ul>
       )}
+
+      {/* 페이지네이션 */}
+      <Pagination
+        currentPage={currentPage}
+        totalPages={totalPages}
+        onPageChange={(page) => fetchComments(page)}
+        groupSize={10}
+      />
     </div>
   );
 }

--- a/frontend/motionit/src/components/VideoListSection.tsx
+++ b/frontend/motionit/src/components/VideoListSection.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { useState } from "react";
+import type { ChallengeVideo } from "@/type";
+import { VideoItem } from "@/components";
+import Pagination from "@/components/common/Pagination";
+
+interface VideoListSectionProps {
+  videos: ChallengeVideo[];
+  roomId: number;
+  onRefresh: () => void;
+}
+
+export default function VideoListSection({ videos, roomId, onRefresh }: VideoListSectionProps) {
+  const pageSize = 4; // 한 페이지당 4개 영상
+  const totalPages = Math.ceil(videos.length / pageSize);
+  const [currentPage, setCurrentPage] = useState(0);
+
+  // 현재 페이지에 맞는 영상만 슬라이싱
+  const startIdx = currentPage * pageSize;
+  const currentVideos = videos.slice(startIdx, startIdx + pageSize);
+
+  return (
+    <div className="space-y-6">
+      {/* 영상 목록 */}
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-6 transition-all duration-300">
+        {currentVideos.map((video) => (
+          <VideoItem key={video.id} video={video} roomId={roomId} onDeleted={onRefresh} />
+        ))}
+      </div>
+
+      {/* 페이지 네비게이션 */}
+      {totalPages > 1 && (
+        <Pagination
+          currentPage={currentPage}
+          totalPages={totalPages}
+          onPageChange={setCurrentPage}
+          groupSize={5}
+        />
+      )}
+    </div>
+  );
+}

--- a/frontend/motionit/src/components/common/Pagination.tsx
+++ b/frontend/motionit/src/components/common/Pagination.tsx
@@ -1,0 +1,110 @@
+"use client";
+
+import { ChevronLeft, ChevronRight, ChevronsLeft, ChevronsRight } from "lucide-react";
+
+interface PaginationProps {
+  currentPage: number;        // 현재 페이지 (0부터 시작)
+  totalPages: number;         // 전체 페이지 수
+  onPageChange: (page: number) => void;
+  groupSize?: number;         // 페이지 버튼 묶음 크기 (기본값 10)
+  className?: string;         // 커스텀 스타일 (선택)
+}
+
+export default function Pagination({
+  currentPage,
+  totalPages,
+  onPageChange,
+  groupSize = 10,
+  className = "",
+}: PaginationProps) {
+  if (totalPages <= 1) return null;
+
+  const currentGroup = Math.floor(currentPage / groupSize);
+  const startPage = currentGroup * groupSize;
+  const endPage = Math.min(startPage + groupSize, totalPages);
+  const visiblePages = Array.from({ length: endPage - startPage }, (_, i) => startPage + i);
+
+  return (
+    <div
+      className={`flex justify-center items-center mt-6 space-x-1 select-none flex-wrap ${className}`}
+    >
+      {/* 처음으로 */}
+      <button
+        disabled={currentPage === 0}
+        onClick={() => onPageChange(0)}
+        className={`flex items-center space-x-1 px-2 py-1 rounded-md text-sm transition-all duration-150
+          ${
+            currentPage === 0
+              ? "text-gray-300 bg-gray-100 cursor-not-allowed"
+              : "text-gray-600 bg-white border hover:bg-green-50 hover:text-green-700"
+          }`}
+      >
+        <ChevronsLeft size={14} />
+        <span>처음</span>
+      </button>
+
+      {/* 이전 그룹 */}
+      <button
+        disabled={currentGroup === 0}
+        onClick={() => onPageChange(Math.max(startPage - 1, 0))}
+        className={`flex items-center space-x-1 px-3 py-1.5 rounded-lg text-sm font-medium transition-all duration-150
+          ${
+            currentGroup === 0
+              ? "text-gray-300 bg-gray-100 cursor-not-allowed"
+              : "text-gray-600 bg-white border hover:bg-green-50 hover:text-green-700"
+          }`}
+      >
+        <ChevronLeft size={16} />
+        <span>이전</span>
+      </button>
+
+      {/* 숫자 버튼 */}
+      <div className="flex space-x-1 mx-1">
+        {visiblePages.map((idx) => (
+          <button
+            key={idx}
+            onClick={() => onPageChange(idx)}
+            className={`w-8 h-8 flex items-center justify-center rounded-md text-sm font-medium transition-all
+              ${
+                idx === currentPage
+                  ? "bg-green-600 text-white shadow-sm"
+                  : "text-gray-600 hover:bg-gray-100"
+              }`}
+          >
+            {idx + 1}
+          </button>
+        ))}
+      </div>
+
+      {/* 다음 그룹 */}
+      <button
+        disabled={endPage >= totalPages}
+        onClick={() => onPageChange(endPage)}
+        className={`flex items-center space-x-1 px-3 py-1.5 rounded-lg text-sm font-medium transition-all duration-150
+          ${
+            endPage >= totalPages
+              ? "text-gray-300 bg-gray-100 cursor-not-allowed"
+              : "text-gray-600 bg-white border hover:bg-green-50 hover:text-green-700"
+          }`}
+      >
+        <span>다음</span>
+        <ChevronRight size={16} />
+      </button>
+
+      {/* 마지막으로 */}
+      <button
+        disabled={currentPage >= totalPages - 1}
+        onClick={() => onPageChange(totalPages - 1)}
+        className={`flex items-center space-x-1 px-2 py-1 rounded-md text-sm transition-all duration-150
+          ${
+            currentPage >= totalPages - 1
+              ? "text-gray-300 bg-gray-100 cursor-not-allowed"
+              : "text-gray-600 bg-white border hover:bg-green-50 hover:text-green-700"
+          }`}
+      >
+        <span>끝</span>
+        <ChevronsRight size={14} />
+      </button>
+    </div>
+  );
+}

--- a/frontend/motionit/src/components/index.tsx
+++ b/frontend/motionit/src/components/index.tsx
@@ -1,3 +1,5 @@
 export { default as UploadVideoForm } from "../components/UploadVideoForm";
 export { default as VideoItem } from "../components/VideoItem";
 export { default as CommentSection } from "../components/CommentSection";
+export { default as Pagination } from "../components/common/Pagination";
+export { default as VideoListSection } from "../components/VideoListSection";


### PR DESCRIPTION
<!--
  템플릿은 아직 PR 작성이 익숙하지 않으신 분들을 위해서 제공하는 가이드입니다!
  리뷰어 또는 이 PR을 보게 될 다른 사람들이 이 PR을 보는데 참고할 수 있는 내용이 있다면 포함해서 작성해주시면 됩니다.
-->

## 관련 이슈

- Close #141 

## PR / 과제 설명 

- 댓글 페이징 구현입니다
   - 댓글 10개단위로 1개 페이지, 10페이지 단위로 네비게이션을 보여주고
   - 10페이지단위 "다음" "이전" 이동 버튼과 제일 처음, 제일 끝으로 이동하는 버튼 추가했습니다
- 추가로 영상도 백엔드에서는 페이징 구현이 없지만
   - 4개 이상 영상 업로드시 페이징 네비게이션이 생성되고 댓글과 동일하게 이동하도록 구현했습니다
