### PR TITLE
[FE] 프론트 운동방상세-미션현황 페이지 사용자 프로필이미지, 닉네임 추가

### DIFF
--- a/frontend/motionit/src/app/rooms/[roomId]/page.tsx
+++ b/frontend/motionit/src/app/rooms/[roomId]/page.tsx
@@ -6,6 +6,7 @@ import { useEffect, useState } from "react";
 import { challengeService } from "@/services";
 import type { ChallengeVideo, ChallengeMissionStatus } from "@/type";
 import { UploadVideoForm, VideoItem, CommentSection, VideoListSection } from "@/components";
+import ParticipantListSection from "@/components/ParticipantListSection";
 
 export default function RoomDetailPage() {
   const params = useParams();
@@ -175,7 +176,7 @@ export default function RoomDetailPage() {
           <h2 className="text-lg font-semibold text-gray-900 mb-4 border-b pb-3">
             오늘의 운동 영상
           </h2>
-          
+
           {/* 운동 영상 */}
           {videos.length === 0 ? (
             <p className="text-gray-500 text-sm">아직 업로드된 영상이 없습니다.</p>
@@ -235,39 +236,7 @@ export default function RoomDetailPage() {
             오늘의 참가자 현황
           </h2>
 
-          {participants.length === 0 ? (
-            <p className="text-gray-500 text-sm">
-              참가자 데이터가 없습니다.
-            </p>
-          ) : (
-            <ul className="space-y-3">
-              {participants.map((p) => (
-                <li
-                  key={p.participantId}
-                  className="flex items-center justify-between border border-gray-100 rounded-xl p-3 shadow-sm"
-                >
-                  <div className="flex items-center space-x-3">
-                    <div className="w-8 h-8 bg-gray-200 rounded-full" />
-                    <span className="font-medium text-gray-800">
-                      참가자 {p.participantId}
-                      {p.isHost === "HOST" && (
-                        <span className="ml-2 text-xs text-blue-600 font-semibold">(방장)</span>
-                      )}
-                    </span>
-                  </div>
-                  <span
-                    className={`text-sm px-3 py-1 rounded-full ${
-                      p.completed
-                        ? "bg-green-100 text-green-700"
-                        : "bg-gray-100 text-gray-500"
-                    }`}
-                  >
-                    {p.completed ? "완료" : "미완료"}
-                  </span>
-                </li>
-              ))}
-            </ul>
-          )}
+          <ParticipantListSection participants={participants} />
         </div>
       )}
     </div>

--- a/frontend/motionit/src/components/ParticipantListSection.tsx
+++ b/frontend/motionit/src/components/ParticipantListSection.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import Image from "next/image";
+import { ChallengeMissionStatus } from "@/type";
+import { CheckCircle, Circle, Crown } from "lucide-react";
+
+interface ParticipantListSectionProps {
+  participants: ChallengeMissionStatus[];
+}
+
+const CLOUDFRONT_DOMAIN = process.env.NEXT_PUBLIC_CLOUD_FRONT_DOMAIN || "";
+
+export default function ParticipantListSection({ participants }: ParticipantListSectionProps) {
+    if (!participants || participants.length === 0) {
+      return <p className="text-gray-500 text-sm">참가자 데이터가 없습니다.</p>;
+    }
+  
+    return (
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+        {participants.map((p) => {
+          const profileUrl = p.userProfile?.startsWith("http")
+            ? p.userProfile
+            : `${CLOUDFRONT_DOMAIN}/${p.userProfile}`;
+  
+          const isHost = p.isHost === "HOST";
+  
+          return (
+            <div
+              key={p.participantId}
+              className="flex items-center space-x-6 bg-white border border-gray-100 rounded-3xl shadow-sm hover:shadow-lg transition-all p-6"
+            >
+                {/* 프로필 이미지 */}
+                <div className="relative flex-shrink-0 w-40 h-40 rounded-full overflow-hidden border border-gray-200 bg-gray-100 shadow-md">
+                {profileUrl ? (
+                    <Image
+                    src={profileUrl}
+                    alt={`${p.nickname} 프로필`}
+                    fill
+                    sizes="160px"
+                    className="object-cover transition-transform duration-200 hover:scale-110"
+                    />
+                ) : (
+                    <div className="flex items-center justify-center h-full text-sm text-gray-400">
+                    No Img
+                    </div>
+                )}
+                </div>
+  
+              {/* 텍스트 영역 */}
+              <div className="flex-1 min-w-0">
+                <div className="flex items-center space-x-3">
+                <p className="font-bold text-gray-900 truncate text-xl">{p.nickname}</p>
+                {isHost && (
+                    <span className="inline-flex items-center" title="방장">
+                    <Crown
+                        size={22}
+                        className="text-yellow-500 -mt-[2px]"
+                        aria-hidden="true"
+                    />
+                    <span className="sr-only">방장</span>
+                    </span>
+                )}
+                </div>
+                <p
+                className={`mt-3 font-medium ${
+                    p.completed ? "text-green-600" : "text-gray-600"
+                } text-lg`}
+                >
+                {p.completed ? "오늘의 운동 완료! 💪" : "아직 미완료 🕓"}
+                </p>
+            </div>
+
+            {/* 완료 상태 아이콘 */}
+            <div className="flex-shrink-0" title={p.completed ? "완료" : "미완료"}>
+                {p.completed ? (
+                <CheckCircle size={30} className="text-green-600" aria-hidden="true" />
+                ) : (
+                <Circle size={30} className="text-gray-400" aria-hidden="true" />
+                )}
+                <span className="sr-only">{p.completed ? "완료" : "미완료"}</span>
+            </div>
+            </div>
+          );
+        })}
+      </div>
+    );
+  }

--- a/frontend/motionit/src/components/index.tsx
+++ b/frontend/motionit/src/components/index.tsx
@@ -3,3 +3,4 @@ export { default as VideoItem } from "../components/VideoItem";
 export { default as CommentSection } from "../components/CommentSection";
 export { default as Pagination } from "../components/common/Pagination";
 export { default as VideoListSection } from "../components/VideoListSection";
+export { default as ParticipantListSection } from "../components/ParticipantListSection";

--- a/frontend/motionit/src/type/roomdetail.type.ts
+++ b/frontend/motionit/src/type/roomdetail.type.ts
@@ -12,6 +12,8 @@ export interface ChallengeVideo {
 
 export interface ChallengeMissionStatus {
   participantId: number;
+  nickname: string;
+  userProfile: string;
   missionDate: string;
   completed: boolean;
   isHost: "HOST" | "MEMBER";

--- a/motionit/src/main/java/com/back/motionit/domain/challenge/mission/dto/ChallengeMissionStatusResponse.java
+++ b/motionit/src/main/java/com/back/motionit/domain/challenge/mission/dto/ChallengeMissionStatusResponse.java
@@ -9,24 +9,35 @@ import com.back.motionit.domain.challenge.participant.entity.ChallengeParticipan
 
 public record ChallengeMissionStatusResponse(
 	Long participantId,
+	String nickname,
+	String userProfile,
 	LocalDate missionDate,
 	boolean completed,
 	ChallengeParticipantRole isHost,
 	@Nullable String aiSummary
 ) {
 	public static ChallengeMissionStatusResponse from(ChallengeMissionStatus status) {
+		var participant = status.getParticipant();
+		var user = participant.getUser(); // TODO: 지연로딩으로 N+1 발생가능지점, 쿼리개선 필요
+
 		return new ChallengeMissionStatusResponse(
 			status.getParticipant().getId(),
+			user.getNickname(),
+			user.getUserProfile(),
 			status.getMissionDate(),
 			status.getCompleted(),
 			status.getParticipant().getRole(),
 			null
 		);
 	}
-	
+
 	public static ChallengeMissionStatusResponse from(ChallengeMissionStatus status, String aiSummary) {
+		var participant = status.getParticipant();
+		var user = participant.getUser();
 		return new ChallengeMissionStatusResponse(
 			status.getParticipant().getId(),
+			user.getNickname(),
+			user.getUserProfile(),
 			status.getMissionDate(),
 			status.getCompleted(),
 			status.getParticipant().getRole(),


### PR DESCRIPTION
<!--
  템플릿은 아직 PR 작성이 익숙하지 않으신 분들을 위해서 제공하는 가이드입니다!
  리뷰어 또는 이 PR을 보게 될 다른 사람들이 이 PR을 보는데 참고할 수 있는 내용이 있다면 포함해서 작성해주시면 됩니다.
-->

## 관련 이슈

- Close #142 

## PR / 과제 설명 

- 프론트 운동방상세-미션현황 페이지 사용자 프로필이미지, 닉네임 추가
- 백엔드 dto에 사용자 프로필 이미지, 닉네임 추가
   - mission > particiapnt > user로 객체를 타고들어가는데,
   - participant까지는 Join쿼리가 구현 되어있지만 user 엔티티는 없음
   - 이때 Lazy로딩으로 쿼리를 한번씩 더 조회할 가능성
   - 때무네 추후에 쿼리개선 필요한 지점 (요청이 많아질 시 병목생길 가능성 매우 큼)

- 프론트에서 프로필 이미지, 닉네임 정보를 받아 그려줌
   - 프로필 카드를 최대 두개까지 가로로 나란히 배치
   - 브라우저 창 영역이 줄어들면 카드 하나씩 세로로 배치

<img width="1239" height="589" alt="image" src="https://github.com/user-attachments/assets/0b123f33-f20f-4b4d-b324-88178b6cd110" />
