### PR TITLE
[FE] refactor: 운동방 참여하기 & 입장하기 상호작용 추가

### DIFF
--- a/frontend/motionit/src/components/confirm-modal/ConfirmModal.tsx
+++ b/frontend/motionit/src/components/confirm-modal/ConfirmModal.tsx
@@ -1,0 +1,94 @@
+'use client';
+
+import { useEffect, useRef } from "react";
+
+interface ConfirmModalProps {
+    open: boolean;
+    title?: string;
+    message?: string;
+    confirmText?: string;
+    cancelText?: string;
+    onConfirm: () => void | Promise<void>;
+    onCancel: () => void;
+}
+
+export default function ConfirmModal({
+    open,
+    title = '확인',
+    message = '챌린지에 참여하시겠어요?',
+    confirmText  = '확인',
+    cancelText = '취소',
+    onConfirm,
+    onCancel,
+}: ConfirmModalProps) {
+    const backdropRef = useRef<HTMLDivElement | null>(null);
+    const firstButtonRef = useRef<HTMLButtonElement | null>(null);
+
+    useEffect(() => {
+        if (!open) {
+            return;
+        }
+
+        const t = setTimeout(() => firstButtonRef.current?.focus(), 0);
+        const onKey = (e: KeyboardEvent) => {
+            if (e.key === 'Escape') {
+                onCancel();
+            }
+        };
+
+        document.addEventListener('keydown', onKey);
+        return () => {
+            clearTimeout(t);
+            document.removeEventListener('keydown', onKey);
+        };
+    }, [open, onCancel]);
+
+    if (!open) {
+        return null;
+    }
+
+    return (
+        <div
+            ref={backdropRef}
+            className="fixed inset-0 z-50"
+            role="dialog"
+            aria-modal="true"
+            onMouseDown={(e) => {
+            if (e.target === backdropRef.current) onCancel();
+            }}
+        >
+        {/* Backdrop */}
+        <div className="absolute inset-0 bg-black/40" />
+  
+        {/* Panel */}
+        <div className="absolute inset-0 flex items-center justify-center p-4">
+          <div className="w-full max-w-md rounded-2xl bg-white shadow-xl">
+            <div className="px-6 py-5">
+              <h2 className="text-lg font-semibold">{title}</h2>
+              <p className="mt-2 text-sm text-neutral-600 whitespace-pre-line">
+                {message}
+              </p>
+  
+              <div className="mt-6 flex justify-end gap-2">
+                <button
+                  ref={firstButtonRef}
+                  type="button"
+                  onClick={onCancel}
+                  className="rounded-lg border px-4 py-2 text-sm hover:bg-neutral-50"
+                >
+                  {cancelText}
+                </button>
+                <button
+                  type="button"
+                  onClick={onConfirm}
+                  className="rounded-lg bg-emerald-600 px-4 py-2 text-sm font-medium text-white hover:bg-emerald-700"
+                >
+                  {confirmText}
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+}

--- a/frontend/motionit/src/components/room-card/RoomCard.tsx
+++ b/frontend/motionit/src/components/room-card/RoomCard.tsx
@@ -1,5 +1,9 @@
 import Image from "next/image";
 import { RoomSummary, ChallengeStatus, RoomCta } from "../../type";
+import { useRouter } from "next/navigation";
+import ConfirmModal from "../confirm-modal/ConfirmModal";
+import { useState } from "react";
+import { challengeService } from "../../services";
 
 const cdnBaseUrl = process.env.NEXT_PUBLIC_CLOUD_FRONT_DOMAIN ?? "";
 
@@ -8,6 +12,19 @@ interface RoomCardProps {
 }
 
 export default function RoomCard({challenge}: RoomCardProps) {
+
+    const router = useRouter();
+
+    const [open, setOpen] = useState(false);
+
+    const handleClickEvent = (status: string): void => {
+        if (status === ChallengeStatus.JOINING) {
+            router.push(`/rooms/${challenge.id}`);
+            return;
+        }
+
+        setOpen(true);
+    }
 
     return (
         <div>
@@ -40,12 +57,24 @@ export default function RoomCard({challenge}: RoomCardProps) {
                         "mt-3 w-full rounded-lg bg-emerald-600 text-white text-sm font-medium py-2 hover:bg-emerald-700 transition"
                         : "mt-3 w-full rounded-lg bg-gray-500 text-white text-sm font-medium py-2 hover:bg-gray-500 transition"
                     }
-                    onClick={() => alert(`${challenge.title} ${RoomCta.JOIN}`)}
+                    onClick={() => handleClickEvent(challenge.status)}
                 >
                     {challenge.status == ChallengeStatus.JOINABLE ? RoomCta.JOIN : RoomCta.GET_IN}
                 </button>
                 </div>
             </article>
+            <ConfirmModal
+                open={open}
+                title={'챌린지 참여'}
+                message={`'${challenge.title}' 챌린지에 참여하시겠어요?`}
+                confirmText={'참여'}
+                cancelText={'취소'}
+                onConfirm={async () => {
+                    await challengeService.joinRoom(challenge.id);
+                    setOpen(false);
+                }}
+                onCancel={() => setOpen(false)}
+            />
         </div>
     )
 }

--- a/frontend/motionit/src/constants/challenge.constant.ts
+++ b/frontend/motionit/src/constants/challenge.constant.ts
@@ -19,6 +19,7 @@ export const CHALLENGE_API = {
   TOGGLE_COMMENT_LIKE: (commentId: number) => `/api/v1/comments/${commentId}/likes`,
   GET_OR_CREATE_ROOMS: () => `/api/v1/challenge/rooms`,
   GET_OR_DELETE_ROOM: (roomId: number) => `/api/v1/challenge/rooms/${roomId}`,
+  JOIN_ROOM: (roomId: number) => `/api/v1/challenge/participants/${roomId}/join`,
 };
 
 export const ROOM_TAB = {

--- a/frontend/motionit/src/services/challenge.service.ts
+++ b/frontend/motionit/src/services/challenge.service.ts
@@ -67,6 +67,7 @@ class ChallengeService {
   toggleCommentLike(commentId: number) {
     return api.post(CHALLENGE_API.TOGGLE_COMMENT_LIKE(commentId));
   }
+
   createRoom(payload: CreateRoomRequest) {
     return api.post(CHALLENGE_API.GET_OR_CREATE_ROOMS(), payload);
   }
@@ -86,6 +87,10 @@ class ChallengeService {
 
   deleteRoom(roomId: number) {
     return api.delete(CHALLENGE_API.GET_OR_DELETE_ROOM(roomId));
+  }
+
+  joinRoom(roomId: number) {
+    return api.post(CHALLENGE_API.JOIN_ROOM(roomId));
   }
 }
 


### PR DESCRIPTION
## 관련 이슈

- Close #136 

## PR / 과제 설명 

- 운동방에서 "입장하기" 및 "참여하기" 버튼을 누를 때, 상호작용 추가.
- "입장하기": 이미 참가 중인 챌린지에 나오는 버튼으로 `{baseUrl}/rooms` 페이지로 이동
- "참여하기": 참여하지 않은 챌린지에 나오는 버튼으로 버튼 클릭 시, 참여 확인 모달이 나오고 모달에서 "참여"를 선택하면, joinRoom API 호출
