### PR TITLE
youtubeVideoId 유니크제약조건 수정

### DIFF
--- a/motionit/src/main/java/com/back/motionit/domain/challenge/video/entity/ChallengeVideo.java
+++ b/motionit/src/main/java/com/back/motionit/domain/challenge/video/entity/ChallengeVideo.java
@@ -13,6 +13,7 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -23,7 +24,15 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Getter
 @Builder
-@Table(name = "challenge_videos")
+@Table(
+	name = "challenge_videos",
+	uniqueConstraints = {
+		@UniqueConstraint(
+			columnNames = {"challenge_room_id", "youtube_video_id"},
+			name = "uk_challenge_room_youtube_video"
+		)
+	}
+)
 public class ChallengeVideo extends BaseEntity {
 	// 어떤 방의 영상인지
 	@ManyToOne(fetch = FetchType.LAZY)
@@ -35,7 +44,7 @@ public class ChallengeVideo extends BaseEntity {
 	private User user;
 
 	// 유튜브 비디오 식별자
-	@Column(unique = true, name = "youtube_video_id", nullable = false)
+	@Column(name = "youtube_video_id", nullable = false)
 	private String youtubeVideoId;
 
 	// 영상 제목 (프론트 표시용)


### PR DESCRIPTION
<!--
  템플릿은 아직 PR 작성이 익숙하지 않으신 분들을 위해서 제공하는 가이드입니다!
  리뷰어 또는 이 PR을 보게 될 다른 사람들이 이 PR을 보는데 참고할 수 있는 내용이 있다면 포함해서 작성해주시면 됩니다.
-->

## 관련 이슈

- Close #147 

## PR / 과제 설명 

- 유니크 제약이 youtubeVideoId 자체에 걸려있어 DB 전체에서 같은영상을 올리지 못하는 현상이 있었음
- 다른방에서 이미 올린 영상이면, 또 다른방에서는 같은 영상을 올리지 못함
- 해결: youtubeVideoId의 unique 제약 삭제, challenge_room_id와 복합 unique로 설정


<1번방>
<img width="1263" height="765" alt="image" src="https://github.com/user-attachments/assets/94b05d14-0139-4e3f-a82e-823c97a1ce91" />
<2번방>
<img width="1261" height="751" alt="image" src="https://github.com/user-attachments/assets/7c2f81c2-b477-4422-be23-f3ae6c61daa5" />
