### PR TITLE
[FE] refactor: 운동방 삭제 API 연동

### DIFF
--- a/frontend/motionit/src/app/auth/login/page.tsx
+++ b/frontend/motionit/src/app/auth/login/page.tsx
@@ -5,6 +5,7 @@ import { FormEvent, useEffect, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { APP_NAME } from "@/constants";
 import { authService } from "@/services";
+import { useUser } from "../../../stores";
 
 const apiBaseUrl = process.env.NEXT_PUBLIC_API_BASE_URL?.replace(/\/$/, "");
 const kakaoAuthEnv = process.env.NEXT_PUBLIC_KAKAO_AUTH_URL?.trim();
@@ -19,6 +20,8 @@ export default function LoginPage() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const registered = searchParams.get("registered") === "true";
+
+  const { setUser } = useUser();
 
   const [formValues, setFormValues] = useState({
     email: "",
@@ -68,10 +71,17 @@ export default function LoginPage() {
 
     setIsSubmitting(true);
     try {
-      await authService.login({
+      const response = await authService.login({
         email: formValues.email.trim(),
         password: formValues.password,
       });
+
+      setUser({
+        id: response.id,
+        nickname: response.nickname,
+        email: response.email,
+      });
+
       router.replace("/rooms");
     } catch (err) {
       setError(

--- a/frontend/motionit/src/constants/index.ts
+++ b/frontend/motionit/src/constants/index.ts
@@ -1,3 +1,4 @@
 export * from './example.constant';
 export * from './challenge.constant';
-export * from './app.constant'
+export * from './app.constant';
+export * from './user.constant';

--- a/frontend/motionit/src/constants/user.constant.ts
+++ b/frontend/motionit/src/constants/user.constant.ts
@@ -1,0 +1,4 @@
+export const ParticipantRole = {
+    HOST: 'HOST',
+    MEMBER: 'MEMBER',
+}

--- a/frontend/motionit/src/services/challenge.service.ts
+++ b/frontend/motionit/src/services/challenge.service.ts
@@ -85,10 +85,6 @@ class ChallengeService {
     return api.get(`${CHALLENGE_API.GET_OR_CREATE_ROOMS()}?${params.toString()}`);
   }
 
-  getRoom(roomId: number) {
-    return api.get(CHALLENGE_API.GET_OR_DELETE_ROOM(roomId));
-  }
-
   deleteRoom(roomId: number) {
     return api.delete(CHALLENGE_API.GET_OR_DELETE_ROOM(roomId));
   }

--- a/frontend/motionit/src/stores/index.ts
+++ b/frontend/motionit/src/stores/index.ts
@@ -1,1 +1,2 @@
 export * from './room.store';
+export * from './user.store';

--- a/frontend/motionit/src/stores/user.store.ts
+++ b/frontend/motionit/src/stores/user.store.ts
@@ -1,0 +1,16 @@
+import { create } from "zustand";
+import { User } from "../type";
+
+interface UserProps {
+    user: User;
+    
+    setUser: (user: User) => void;
+}
+
+export const useUser = create<UserProps>((set, get) => ({
+    user: { id: 0, nickname: "", email: "" },
+
+    setUser: (user: User) => {
+        set({ user: { id: user.id, nickname: user.nickname, email: user.email } });
+    }
+}))

--- a/frontend/motionit/src/type/index.ts
+++ b/frontend/motionit/src/type/index.ts
@@ -1,3 +1,4 @@
 export * from './room.type';
 export * from './roomdetail.type';
 export * from './event.type';
+export * from './user.type';

--- a/frontend/motionit/src/type/user.type.ts
+++ b/frontend/motionit/src/type/user.type.ts
@@ -1,0 +1,5 @@
+export interface User {
+    id: number;
+    nickname: string;
+    email: string;
+}


### PR DESCRIPTION
## 관련 이슈

- Close #138 

## PR / 과제 설명 

- 운동방에서 "HOST" 역할을 가진 방장만 운동방 삭제를 할 수 있도록 추가
- `DELETE /api/v1/rooms/{roomId}` API 연결

**시연 영상**

https://github.com/user-attachments/assets/95cb660b-e258-4b57-bfab-cdd840fb6f2e



