### PR TITLE
백엔드 댓글 소켓 처리, 댓글 글자수 200제한

### DIFF
--- a/motionit/src/main/java/com/back/motionit/domain/challenge/comment/entity/Comment.java
+++ b/motionit/src/main/java/com/back/motionit/domain/challenge/comment/entity/Comment.java
@@ -45,7 +45,7 @@ public class Comment extends BaseEntity {
 	@JoinColumn(name = "author_id", nullable = false)
 	private User user;
 
-	@Column(nullable = false, length = 1000)
+	@Column(nullable = false, length = 200)
 	private String content;
 
 	@Builder.Default

--- a/motionit/src/main/java/com/back/motionit/domain/challenge/comment/event/CommentEventBroadcaster.java
+++ b/motionit/src/main/java/com/back/motionit/domain/challenge/comment/event/CommentEventBroadcaster.java
@@ -1,0 +1,24 @@
+package com.back.motionit.domain.challenge.comment.event;
+
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import com.back.motionit.global.event.Broadcaster;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class CommentEventBroadcaster implements Broadcaster<CommentEventDto> {
+
+	private final SimpMessagingTemplate messagingTemplate;
+
+	@Override
+	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+	public void onCreated(CommentEventDto event) {
+		String dest = "/topic/rooms/" + event.getRoomId() + "/comments";
+		messagingTemplate.convertAndSend(dest, event);
+	}
+}

--- a/motionit/src/main/java/com/back/motionit/domain/challenge/comment/event/CommentEventDto.java
+++ b/motionit/src/main/java/com/back/motionit/domain/challenge/comment/event/CommentEventDto.java
@@ -1,0 +1,14 @@
+package com.back.motionit.domain.challenge.comment.event;
+
+import com.back.motionit.domain.challenge.comment.dto.CommentRes;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class CommentEventDto {
+	public enum Type { CREATED, UPDATED, DELETED }
+	private final Long roomId;
+	private final Type type;
+	private final CommentRes payload;
+}

--- a/motionit/src/main/java/com/back/motionit/security/config/SecurityConfig.java
+++ b/motionit/src/main/java/com/back/motionit/security/config/SecurityConfig.java
@@ -93,6 +93,7 @@ public class SecurityConfig {
 			// 구독(/topic/**) 경로별 권한
 			.simpSubscribeDestMatchers("/topic/challenge/rooms").permitAll() // 전체 방 목록: 게스트 허용
 			.simpSubscribeDestMatchers("/topic/challenge/rooms/*").authenticated() // 로그인만 허용
+			.simpSubscribeDestMatchers("/topic/rooms/*/comments").authenticated()// 댓글 토픽 구독 허용
 			// 전송(/app/**) 경로별 권한
 			.simpDestMatchers("/app/**").authenticated()
 			// 나머지 모두 차단


### PR DESCRIPTION


## PR / 과제 설명 
1.백엔드 댓글 소켓 처리
댓글 작성, 수정, 삭제 시 CommentEventDto 발행

CommentEventBroadcaster가 /topic/rooms/{roomId}/comments 경로로 이벤트 브로드캐스트

CommentEventDto.Type에 따라 프론트에서 실시간 갱신 가능 (CREATED, UPDATED, DELETED)
2. 댓글 글자수 제한 200으로 변경
Comment entity에서 length=200으로 변경